### PR TITLE
Use JDK 17 syntax

### DIFF
--- a/ast/src/main/java/net/hamnaberg/json/Folder.java
+++ b/ast/src/main/java/net/hamnaberg/json/Folder.java
@@ -1,0 +1,87 @@
+package net.hamnaberg.json;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public interface Folder<A> {
+    A onNull();
+
+    A onBoolean(Json.JBoolean b);
+
+    A onNumber(Json.JNumber n);
+
+    A onString(Json.JString s);
+
+    A onArray(Json.JArray a);
+
+    A onObject(Json.JObject o);
+
+    default VoidFolder toVoid() {
+        var self = this;
+        return new VoidFolder() {
+            @Override
+            public void onNull() {
+                self.onNull();
+            }
+
+            @Override
+            public void onBoolean(Json.JBoolean b) {
+                self.onBoolean(b);
+            }
+
+            @Override
+            public void onNumber(Json.JNumber n) {
+                self.onNumber(n);
+            }
+
+            @Override
+            public void onString(Json.JString s) {
+                self.onString(s);
+            }
+
+            @Override
+            public void onArray(Json.JArray a) {
+                self.onArray(a);
+            }
+
+            @Override
+            public void onObject(Json.JObject o) {
+                self.onObject(o);
+            }
+        };
+    }
+
+    static <X> Folder<X> from(Function<Json.JString, X> fString, Function<Json.JBoolean, X> fBoolean, Function<Json.JNumber, X> fNumber, Function<Json.JObject, X> fObject, Function<Json.JArray, X> fArray, Supplier<X> fNull) {
+        return new Folder<>() {
+            @Override
+            public X onNull() {
+                return fNull.get();
+            }
+
+            @Override
+            public X onBoolean(Json.JBoolean b) {
+                return fBoolean.apply(b);
+            }
+
+            @Override
+            public X onNumber(Json.JNumber n) {
+                return fNumber.apply(n);
+            }
+
+            @Override
+            public X onString(Json.JString s) {
+                return fString.apply(s);
+            }
+
+            @Override
+            public X onArray(Json.JArray a) {
+                return fArray.apply(a);
+            }
+
+            @Override
+            public X onObject(Json.JObject o) {
+                return fObject.apply(o);
+            }
+        };
+    }
+}

--- a/ast/src/main/java/net/hamnaberg/json/Json.java
+++ b/ast/src/main/java/net/hamnaberg/json/Json.java
@@ -55,12 +55,12 @@ public abstract class Json {
 
     public static JArray jArray(Iterable<JValue> iterable) {
         Objects.requireNonNull(iterable, "iterable was null");
-        List<JValue> list = StreamSupport.stream(iterable.spliterator(), false).collect(Collectors.toUnmodifiableList());
+        List<JValue> list = StreamSupport.stream(iterable.spliterator(), false).toList();
         return new JArray(list);
     }
 
     public static JArray jArray(JValue first, JValue... rest) {
-        return new JArray(Stream.concat(Stream.of(first), Stream.of(rest)).collect(Collectors.toUnmodifiableList()));
+        return new JArray(Stream.concat(Stream.of(first), Stream.of(rest)).toList());
     }
 
     public static JObject jEmptyObject() {
@@ -68,10 +68,7 @@ public abstract class Json {
     }
 
     public static JObject jObject(String name, JValue value) {
-        return new JObject(Map.of(
-                Objects.requireNonNull(name, "Name for entry may not be null"),
-                Objects.requireNonNull(value, String.format("Value for named entry '%s' may not be null", name))
-        ));
+        return new JObject(Map.of(Objects.requireNonNull(name, "Name for entry may not be null"), Objects.requireNonNull(value, String.format("Value for named entry '%s' may not be null", name))));
     }
 
     public static JObject jObject(String name, String value) {
@@ -118,157 +115,40 @@ public abstract class Json {
         return new JObject(copyOf(value));
     }
 
-    public static JObject jObject(
-            String k1, JValue v1,
-            String k2, JValue v2) {
-        return jObject(
-                tuple(k1, v1),
-                tuple(k2, v2)
-        );
+    public static JObject jObject(String k1, JValue v1, String k2, JValue v2) {
+        return jObject(tuple(k1, v1), tuple(k2, v2));
     }
 
-    public static JObject jObject(
-            String k1, JValue v1,
-            String k2, JValue v2,
-            String k3, JValue v3) {
-        return jObject(
-                tuple(k1, v1),
-                tuple(k2, v2),
-                tuple(k3, v3)
-        );
+    public static JObject jObject(String k1, JValue v1, String k2, JValue v2, String k3, JValue v3) {
+        return jObject(tuple(k1, v1), tuple(k2, v2), tuple(k3, v3));
     }
 
-    public static JObject jObject(
-            String k1, JValue v1,
-            String k2, JValue v2,
-            String k3, JValue v3,
-            String k4, JValue v4) {
-        return jObject(
-                tuple(k1, v1),
-                tuple(k2, v2),
-                tuple(k3, v3),
-                tuple(k4, v4)
-        );
+    public static JObject jObject(String k1, JValue v1, String k2, JValue v2, String k3, JValue v3, String k4, JValue v4) {
+        return jObject(tuple(k1, v1), tuple(k2, v2), tuple(k3, v3), tuple(k4, v4));
     }
 
-    public static JObject jObject(
-            String k1, JValue v1,
-            String k2, JValue v2,
-            String k3, JValue v3,
-            String k4, JValue v4,
-            String k5, JValue v5) {
-        return jObject(
-                tuple(k1, v1),
-                tuple(k2, v2),
-                tuple(k3, v3),
-                tuple(k4, v4),
-                tuple(k5, v5)
-        );
+    public static JObject jObject(String k1, JValue v1, String k2, JValue v2, String k3, JValue v3, String k4, JValue v4, String k5, JValue v5) {
+        return jObject(tuple(k1, v1), tuple(k2, v2), tuple(k3, v3), tuple(k4, v4), tuple(k5, v5));
     }
 
-    public static JObject jObject(
-            String k1, JValue v1,
-            String k2, JValue v2,
-            String k3, JValue v3,
-            String k4, JValue v4,
-            String k5, JValue v5,
-            String k6, JValue v6) {
-        return jObject(
-                tuple(k1, v1),
-                tuple(k2, v2),
-                tuple(k3, v3),
-                tuple(k4, v4),
-                tuple(k5, v5),
-                tuple(k6, v6)
-        );
+    public static JObject jObject(String k1, JValue v1, String k2, JValue v2, String k3, JValue v3, String k4, JValue v4, String k5, JValue v5, String k6, JValue v6) {
+        return jObject(tuple(k1, v1), tuple(k2, v2), tuple(k3, v3), tuple(k4, v4), tuple(k5, v5), tuple(k6, v6));
     }
 
-    public static JObject jObject(
-            String k1, JValue v1,
-            String k2, JValue v2,
-            String k3, JValue v3,
-            String k4, JValue v4,
-            String k5, JValue v5,
-            String k6, JValue v6,
-            String k7, JValue v7) {
-        return jObject(
-                tuple(k1, v1),
-                tuple(k2, v2),
-                tuple(k3, v3),
-                tuple(k4, v4),
-                tuple(k5, v5),
-                tuple(k6, v6),
-                tuple(k7, v7)
-        );
+    public static JObject jObject(String k1, JValue v1, String k2, JValue v2, String k3, JValue v3, String k4, JValue v4, String k5, JValue v5, String k6, JValue v6, String k7, JValue v7) {
+        return jObject(tuple(k1, v1), tuple(k2, v2), tuple(k3, v3), tuple(k4, v4), tuple(k5, v5), tuple(k6, v6), tuple(k7, v7));
     }
 
-    public static JObject jObject(
-            String k1, JValue v1,
-            String k2, JValue v2,
-            String k3, JValue v3,
-            String k4, JValue v4,
-            String k5, JValue v5,
-            String k6, JValue v6,
-            String k7, JValue v7,
-            String k8, JValue v8) {
-        return jObject(
-                tuple(k1, v1),
-                tuple(k2, v2),
-                tuple(k3, v3),
-                tuple(k4, v4),
-                tuple(k5, v5),
-                tuple(k6, v6),
-                tuple(k7, v7),
-                tuple(k8, v8)
-        );
+    public static JObject jObject(String k1, JValue v1, String k2, JValue v2, String k3, JValue v3, String k4, JValue v4, String k5, JValue v5, String k6, JValue v6, String k7, JValue v7, String k8, JValue v8) {
+        return jObject(tuple(k1, v1), tuple(k2, v2), tuple(k3, v3), tuple(k4, v4), tuple(k5, v5), tuple(k6, v6), tuple(k7, v7), tuple(k8, v8));
     }
 
-    public static JObject jObject(
-            String k1, JValue v1,
-            String k2, JValue v2,
-            String k3, JValue v3,
-            String k4, JValue v4,
-            String k5, JValue v5,
-            String k6, JValue v6,
-            String k7, JValue v7,
-            String k8, JValue v8,
-            String k9, JValue v9) {
-        return jObject(
-                tuple(k1, v1),
-                tuple(k2, v2),
-                tuple(k3, v3),
-                tuple(k4, v4),
-                tuple(k5, v5),
-                tuple(k6, v6),
-                tuple(k7, v7),
-                tuple(k8, v8),
-                tuple(k9, v9)
-        );
+    public static JObject jObject(String k1, JValue v1, String k2, JValue v2, String k3, JValue v3, String k4, JValue v4, String k5, JValue v5, String k6, JValue v6, String k7, JValue v7, String k8, JValue v8, String k9, JValue v9) {
+        return jObject(tuple(k1, v1), tuple(k2, v2), tuple(k3, v3), tuple(k4, v4), tuple(k5, v5), tuple(k6, v6), tuple(k7, v7), tuple(k8, v8), tuple(k9, v9));
     }
 
-    public static JObject jObject(
-            String k1, JValue v1,
-            String k2, JValue v2,
-            String k3, JValue v3,
-            String k4, JValue v4,
-            String k5, JValue v5,
-            String k6, JValue v6,
-            String k7, JValue v7,
-            String k8, JValue v8,
-            String k9, JValue v9,
-            String k10, JValue v10) {
-        return jObject(
-                tuple(k1, v1),
-                tuple(k2, v2),
-                tuple(k3, v3),
-                tuple(k4, v4),
-                tuple(k5, v5),
-                tuple(k6, v6),
-                tuple(k7, v7),
-                tuple(k8, v8),
-                tuple(k9, v9),
-                tuple(k10, v10)
-        );
+    public static JObject jObject(String k1, JValue v1, String k2, JValue v2, String k3, JValue v3, String k4, JValue v4, String k5, JValue v5, String k6, JValue v6, String k7, JValue v7, String k8, JValue v8, String k9, JValue v9, String k10, JValue v10) {
+        return jObject(tuple(k1, v1), tuple(k2, v2), tuple(k3, v3), tuple(k4, v4), tuple(k5, v5), tuple(k6, v6), tuple(k7, v7), tuple(k8, v8), tuple(k9, v9), tuple(k10, v10));
     }
 
     public static JObject jObject(Map<String, JValue> value) {
@@ -276,10 +156,7 @@ public abstract class Json {
     }
 
     public static Map.Entry<String, JValue> tuple(String name, JValue value) {
-        return Map.entry(
-                Objects.requireNonNull(name, "Name for entry may not be null"),
-                Objects.requireNonNull(value, String.format("Value for named entry '%s' may not be null", name))
-        );
+        return Map.entry(Objects.requireNonNull(name, "Name for entry may not be null"), Objects.requireNonNull(value, String.format("Value for named entry '%s' may not be null", name)));
     }
 
     public static Map.Entry<String, JValue> tuple(String name, Optional<JValue> opt) {
@@ -350,14 +227,176 @@ public abstract class Json {
         return (ignore) -> Optional.empty();
     }
 
-    public static abstract class JValue implements Serializable {
+    public interface Folder<A> {
+        A onNull();
 
-        private JValue() {
+        A onBoolean(JBoolean b);
+
+        A onNumber(JNumber n);
+
+        A onString(JString s);
+
+        A onArray(JArray a);
+
+        A onObject(JObject o);
+
+        default VoidFolder toVoid() {
+            var self = this;
+            return new VoidFolder() {
+                @Override
+                public void onNull() {
+                    self.onNull();
+                }
+
+                @Override
+                public void onBoolean(JBoolean b) {
+                    self.onBoolean(b);
+                }
+
+                @Override
+                public void onNumber(JNumber n) {
+                    self.onNumber(n);
+                }
+
+                @Override
+                public void onString(JString s) {
+                    self.onString(s);
+                }
+
+                @Override
+                public void onArray(JArray a) {
+                    self.onArray(a);
+                }
+
+                @Override
+                public void onObject(JObject o) {
+                    self.onObject(o);
+                }
+            };
         }
 
-        public abstract boolean equals(Object obj);
+        static <X> Folder<X> from(Function<JString, X> fString, Function<JBoolean, X> fBoolean, Function<JNumber, X> fNumber, Function<JObject, X> fObject, Function<JArray, X> fArray, Supplier<X> fNull) {
+            return new Folder<>() {
+                @Override
+                public X onNull() {
+                    return fNull.get();
+                }
 
-        public abstract int hashCode();
+                @Override
+                public X onBoolean(JBoolean b) {
+                    return fBoolean.apply(b);
+                }
+
+                @Override
+                public X onNumber(JNumber n) {
+                    return fNumber.apply(n);
+                }
+
+                @Override
+                public X onString(JString s) {
+                    return fString.apply(s);
+                }
+
+                @Override
+                public X onArray(JArray a) {
+                    return fArray.apply(a);
+                }
+
+                @Override
+                public X onObject(JObject o) {
+                    return fObject.apply(o);
+                }
+            };
+        }
+    }
+
+    public static class OptionalFolder<A> implements Folder<Optional<A>> {
+        @Override
+        public Optional<A> onNull() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<A> onBoolean(JBoolean b) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<A> onNumber(JNumber n) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<A> onString(JString s) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<A> onArray(JArray a) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<A> onObject(JObject o) {
+            return Optional.empty();
+        }
+    }
+
+    public interface VoidFolder {
+        default void onNull() {
+        }
+
+        default void onBoolean(JBoolean b) {
+        }
+
+        default void onNumber(JNumber n) {
+        }
+
+        default void onString(JString s) {
+        }
+
+        default void onArray(JArray a) {
+        }
+
+        default void onObject(JObject o) {
+        }
+
+        static VoidFolder from(Consumer<JString> fString, Consumer<JBoolean> fBoolean, Consumer<JNumber> fNumber, Consumer<JObject> fObject, Consumer<JArray> fArray, Runnable fNull) {
+            return new VoidFolder() {
+                @Override
+                public void onNull() {
+                    fNull.run();
+                }
+
+                @Override
+                public void onBoolean(JBoolean b) {
+                    fBoolean.accept(b);
+                }
+
+                @Override
+                public void onNumber(JNumber n) {
+                    fNumber.accept(n);
+                }
+
+                @Override
+                public void onString(JString s) {
+                    fString.accept(s);
+                }
+
+                @Override
+                public void onArray(JArray a) {
+                    fArray.accept(a);
+                }
+
+                @Override
+                public void onObject(JObject o) {
+                    fObject.accept(o);
+                }
+            };
+        }
+    }
+
+    public sealed interface JValue extends Serializable permits JNull, JBoolean, JNumber, JString, JObject, JArray {
 
         /**
          * This is NOT the json representation. For that you
@@ -365,91 +404,151 @@ public abstract class Json {
          *
          * @return as String describing the data structure.
          */
-        public abstract String toString();
+        String toString();
 
-        public abstract <X> X fold(Function<JString, X> fString,
-                                   Function<JBoolean, X> fBoolean,
-                                   Function<JNumber, X> fNumber,
-                                   Function<JObject, X> fObject,
-                                   Function<JArray, X> fArray,
-                                   Supplier<X> fNull);
+        <X> X fold(Folder<X> folder);
 
-        public abstract void foldUnit(Consumer<JString> fString,
-                                      Consumer<JBoolean> fBoolean,
-                                      Consumer<JNumber> fNumber,
-                                      Consumer<JObject> fObject,
-                                      Consumer<JArray> fArray,
-                                      Runnable fNull);
+        void foldUnit(VoidFolder folder);
 
-        public final Optional<JArray> asJsonArray() {
-            return fold(Json.emptyOption(), Json.emptyOption(), Json.emptyOption(), Json.emptyOption(), Optional::of, Optional::empty);
+        default Optional<JArray> asJsonArray() {
+            return fold(new OptionalFolder<>() {
+                @Override
+                public Optional<JArray> onArray(JArray a) {
+                    return Optional.of(a);
+                }
+            });
         }
 
-        public final JArray asJsonArrayOrEmpty() {
+        default JArray asJsonArrayOrEmpty() {
             return asJsonArray().orElse(jEmptyArray());
         }
 
-        public final Optional<JObject> asJsonObject() {
-            return fold(Json.emptyOption(), Json.emptyOption(), Json.emptyOption(), Optional::of, Json.emptyOption(), Optional::empty);
+        default Optional<JObject> asJsonObject() {
+            return fold(new OptionalFolder<>() {
+                @Override
+                public Optional<JObject> onObject(JObject o) {
+                    return Optional.of(o);
+                }
+            });
         }
 
-        public final JObject asJsonObjectOrEmpty() {
+        default JObject asJsonObjectOrEmpty() {
             return asJsonObject().orElse(jEmptyObject());
         }
 
-        public final Optional<JBoolean> asJsonBoolean() {
-            return fold(Json.emptyOption(), Optional::of, Json.emptyOption(), Json.emptyOption(), Json.emptyOption(), Optional::empty);
+        default Optional<JBoolean> asJsonBoolean() {
+            return fold(new OptionalFolder<>() {
+                @Override
+                public Optional<JBoolean> onBoolean(JBoolean b) {
+                    return Optional.of(b);
+                }
+            });
         }
 
-        public final Optional<Boolean> asBoolean() {
+        default Optional<Boolean> asBoolean() {
             return asJsonBoolean().map(j -> j.value);
         }
 
-        public final Optional<JNull> asJsonNull() {
-            return fold(Json.emptyOption(), Json.emptyOption(), Json.emptyOption(), Json.emptyOption(), Json.emptyOption(), () -> Optional.of(jNull()));
+        default Optional<JNull> asJsonNull() {
+            return fold(new OptionalFolder<>() {
+                @Override
+                public Optional<JNull> onNull() {
+                    return Optional.of(JNull.INSTANCE);
+                }
+            });
         }
 
-        public final Optional<JString> asJsonString() {
-            return fold(Optional::of, Json.emptyOption(), Json.emptyOption(), Json.emptyOption(), Json.emptyOption(), Optional::empty);
+        default Optional<JString> asJsonString() {
+            return fold(new OptionalFolder<>() {
+                @Override
+                public Optional<JString> onString(JString s) {
+                    return Optional.of(s);
+                }
+            });
         }
 
-        public final Optional<String> asString() {
+        default Optional<String> asString() {
             return asJsonString().map(j -> j.value);
         }
 
-        public final Optional<JNumber> asJsonNumber() {
-            return fold(Json.emptyOption(), Json.emptyOption(), Optional::of, Json.emptyOption(), Json.emptyOption(), Optional::empty);
+        default Optional<JNumber> asJsonNumber() {
+            return fold(new OptionalFolder<>() {
+                @Override
+                public Optional<JNumber> onNumber(JNumber n) {
+                    return Optional.of(n);
+                }
+            });
         }
 
-        public final Optional<BigDecimal> asBigDecimal() {
+        default Optional<BigDecimal> asBigDecimal() {
             return asJsonNumber().map(j -> j.value);
         }
 
 
-        public final boolean isObject() { return asJsonObject().isPresent(); }
-        public final boolean isArray() { return asJsonArray().isPresent(); }
-        public final boolean isString() { return asJsonString().isPresent(); }
-        public final boolean isNull() { return asJsonNull().isPresent(); }
-        public final boolean isBoolean() { return asJsonBoolean().isPresent(); }
-        public final boolean isNumber() { return asJsonNumber().isPresent(); }
-
-        public final boolean isScalar() {
-            return fold(j -> true, j -> true, j -> true, j -> false, j -> false, () -> true);
+        default boolean isObject() {
+            return asJsonObject().isPresent();
         }
 
-        public final JValue mapJson(Function<JValue, JValue> f) {
+        default boolean isArray() {
+            return asJsonArray().isPresent();
+        }
+
+        default boolean isString() {
+            return asJsonString().isPresent();
+        }
+
+        default boolean isNull() {
+            return asJsonNull().isPresent();
+        }
+
+        default boolean isBoolean() {
+            return asJsonBoolean().isPresent();
+        }
+
+        default boolean isNumber() {
+            return asJsonNumber().isPresent();
+        }
+
+        default boolean isScalar() {
+            return fold(IsScalarFolder.INSTANCE);
+        }
+
+        default JValue mapJson(Function<JValue, JValue> f) {
             return f.apply(this);
         }
 
-        public final Optional<String> scalarToString() {
-            return fold(
-                    j -> Optional.of(j.value),
-                    j -> Optional.of(String.valueOf(j.value)),
-                    j -> Optional.of(j.value.toString()),
-                    emptyOption(),
-                    emptyOption(),
-                    () -> Optional.of("null")
-            );
+        default Optional<String> scalarToString() {
+            return fold(new Folder<>() {
+                @Override
+                public Optional<String> onNull() {
+                    return Optional.of("null");
+                }
+
+                @Override
+                public Optional<String> onBoolean(JBoolean b) {
+                    return Optional.of(String.valueOf(b.value));
+                }
+
+                @Override
+                public Optional<String> onNumber(JNumber n) {
+                    return Optional.of(n.value.toString());
+                }
+
+                @Override
+                public Optional<String> onString(JString s) {
+                    return Optional.of(s.value);
+                }
+
+                @Override
+                public Optional<String> onArray(JArray a) {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<String> onObject(JObject o) {
+                    return Optional.empty();
+                }
+            });
         }
 
         /**
@@ -463,80 +562,93 @@ public abstract class Json {
          * and values from the argument JSON completely replace values
          * from this JSON.
          */
-        public final JValue deepmerge(JValue value) {
+        default JValue deepmerge(JValue value) {
             Optional<JObject> first = asJsonObject();
             Optional<JObject> second = value.asJsonObject();
 
             if (first.isPresent() && second.isPresent()) {
                 return second.get().stream().reduce(first.get(), (obj, kv) -> {
                     Optional<JValue> v1 = obj.get(kv.getKey());
-                    if (v1.isPresent()) {
-                        return obj.put(kv.getKey(), v1.get().deepmerge(kv.getValue()));
-                    } else {
-                        return obj.put(kv.getKey(), kv.getValue());
-                    }
+                    return v1.map(jValue -> obj.put(kv.getKey(), jValue.deepmerge(kv.getValue()))).orElseGet(() -> obj.put(kv.getKey(), kv.getValue()));
                 }, JObject::concat);
             } else {
                 return value;
             }
         }
 
-        public final JValue asJValue() {
+        default JValue asJValue() {
             return this;
         }
 
-        public final String nospaces() {
+        default String nospaces() {
             return pretty(PrettyPrinter.nospaces());
         }
 
-        public final String spaces2() {
+        default String spaces2() {
             return pretty(PrettyPrinter.spaces2());
         }
 
-        public final String spaces4() {
+        default String spaces4() {
             return pretty(PrettyPrinter.spaces4());
         }
 
-        public final String pretty(PrettyPrinter p) {
+        default String pretty(PrettyPrinter p) {
             return p.writeString(this);
+        }
+
+        enum IsScalarFolder implements Folder<Boolean> {
+            INSTANCE;
+
+            @Override
+            public Boolean onNull() {
+                return true;
+            }
+
+            @Override
+            public Boolean onBoolean(JBoolean b) {
+                return true;
+            }
+
+            @Override
+            public Boolean onNumber(JNumber n) {
+                return true;
+            }
+
+            @Override
+            public Boolean onString(JString s) {
+                return true;
+            }
+
+            @Override
+            public Boolean onArray(JArray a) {
+                return false;
+            }
+
+            @Override
+            public Boolean onObject(JObject o) {
+                return false;
+            }
         }
     }
 
-    public static final class JString extends JValue {
-        public final String value;
-
-        private JString(String value) {
+    public record JString(String value) implements JValue {
+        public JString(String value) {
             this.value = Objects.requireNonNull(value, "String may not be null");
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            JString jString = (JString) o;
-            return Objects.equals(value, jString.value);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(value);
-        }
-
-        @Override
         public String toString() {
-            return "JString{" +
-                    "value='" + value + '\'' +
-                    '}';
+            return "JString{" + "value='" + value + "\"'}";
         }
 
         @Override
-        public <X> X fold(Function<JString, X> fString, Function<JBoolean, X> fBoolean, Function<JNumber, X> fNumber, Function<JObject, X> fObject, Function<JArray, X> fArray, Supplier<X> fNull) {
-            return fString.apply(this);
+        public <X> X fold(Folder<X> f) {
+            return f.onString(this);
         }
 
         @Override
-        public void foldUnit(Consumer<JString> fString, Consumer<JBoolean> fBoolean, Consumer<JNumber> fNumber, Consumer<JObject> fObject, Consumer<JArray> fArray, Runnable fNull) {
-            fString.accept(this);
+        public void foldUnit(VoidFolder f) {
+            f.onString(this);
         }
 
         public String getValue() {
@@ -544,41 +656,20 @@ public abstract class Json {
         }
     }
 
-    public static final class JBoolean extends JValue {
-        public final boolean value;
-
-        private JBoolean(boolean value) {
-            this.value = value;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            JBoolean jBoolean = (JBoolean) o;
-            return value == jBoolean.value;
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(value);
-        }
-
+    public record JBoolean(boolean value) implements JValue {
         @Override
         public String toString() {
-            return "JBoolean{" +
-                    "value=" + value +
-                    '}';
+            return "JBoolean{" + "value=" + value + "}";
         }
 
         @Override
-        public <X> X fold(Function<JString, X> fString, Function<JBoolean, X> fBoolean, Function<JNumber, X> fNumber, Function<JObject, X> fObject, Function<JArray, X> fArray, Supplier<X> fNull) {
-            return fBoolean.apply(this);
+        public <X> X fold(Folder<X> f) {
+            return f.onBoolean(this);
         }
 
         @Override
-        public void foldUnit(Consumer<JString> fString, Consumer<JBoolean> fBoolean, Consumer<JNumber> fNumber, Consumer<JObject> fObject, Consumer<JArray> fArray, Runnable fNull) {
-            fBoolean.accept(this);
+        public void foldUnit(VoidFolder f) {
+            f.onBoolean(this);
         }
 
         public boolean isValue() {
@@ -586,22 +677,8 @@ public abstract class Json {
         }
     }
 
-    public static final class JNull extends JValue {
-        public static final JNull INSTANCE = new JNull();
-
-        private JNull() {
-        }
-
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            return true;
-        }
-
-        @Override
-        public int hashCode() {
-            return 31;
-        }
+    public enum JNull implements JValue {
+        INSTANCE;
 
         @Override
         public String toString() {
@@ -609,52 +686,35 @@ public abstract class Json {
         }
 
         @Override
-        public <X> X fold(Function<JString, X> fString, Function<JBoolean, X> fBoolean, Function<JNumber, X> fNumber, Function<JObject, X> fObject, Function<JArray, X> fArray, Supplier<X> fNull) {
-            return fNull.get();
+        public <X> X fold(Folder<X> f) {
+            return f.onNull();
         }
 
         @Override
-        public void foldUnit(Consumer<JString> fString, Consumer<JBoolean> fBoolean, Consumer<JNumber> fNumber, Consumer<JObject> fObject, Consumer<JArray> fArray, Runnable fNull) {
-            fNull.run();
+        public void foldUnit(VoidFolder f) {
+            f.onNull();
         }
     }
 
-    public static final class JNumber extends JValue {
-        public final BigDecimal value;
+    public record JNumber(BigDecimal value) implements JValue {
 
-        private JNumber(BigDecimal value) {
+        public JNumber(BigDecimal value) {
             this.value = Objects.requireNonNull(value, "Number may not be null");
-        }
-
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            JNumber jNumber = (JNumber) o;
-            return Objects.equals(value, jNumber.value);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(value);
         }
 
         @Override
         public String toString() {
-            return "JNumber{" +
-                    "value=" + value +
-                    '}';
+            return "JNumber{" + "value=" + value + "}";
         }
 
         @Override
-        public <X> X fold(Function<JString, X> fString, Function<JBoolean, X> fBoolean, Function<JNumber, X> fNumber, Function<JObject, X> fObject, Function<JArray, X> fArray, Supplier<X> fNull) {
-            return fNumber.apply(this);
+        public <X> X fold(Folder<X> f) {
+            return f.onNumber(this);
         }
 
         @Override
-        public void foldUnit(Consumer<JString> fString, Consumer<JBoolean> fBoolean, Consumer<JNumber> fNumber, Consumer<JObject> fObject, Consumer<JArray> fArray, Runnable fNull) {
-            fNumber.accept(this);
+        public void foldUnit(VoidFolder f) {
+            f.onNumber(this);
         }
 
         public long asLong() {
@@ -674,41 +734,25 @@ public abstract class Json {
         }
     }
 
-    public static final class JArray extends JValue implements Iterable<JValue> {
-        public final List<JValue> value;
+    public record JArray(List<JValue> value) implements JValue, Iterable<JValue> {
 
-        private JArray(List<JValue> value) {
+        public JArray(List<JValue> value) {
             this.value = Objects.requireNonNull(value, "You may not supply a null List in JArray");
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            JArray jValues = (JArray) o;
-            return Objects.equals(value, jValues.value);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(value);
-        }
-
-        @Override
         public String toString() {
-            return "JArray{" +
-                    "value=" + value +
-                    '}';
+            return "JArray{" + "value=" + value + "}";
         }
 
         @Override
-        public <X> X fold(Function<JString, X> fString, Function<JBoolean, X> fBoolean, Function<JNumber, X> fNumber, Function<JObject, X> fObject, Function<JArray, X> fArray, Supplier<X> fNull) {
-            return fArray.apply(this);
+        public <X> X fold(Folder<X> f) {
+            return f.onArray(this);
         }
 
         @Override
-        public void foldUnit(Consumer<JString> fString, Consumer<JBoolean> fBoolean, Consumer<JNumber> fNumber, Consumer<JObject> fObject, Consumer<JArray> fArray, Runnable fNull) {
-            fArray.accept(this);
+        public void foldUnit(VoidFolder f) {
+            f.onArray(this);
         }
 
         public List<JValue> getValue() {
@@ -745,11 +789,11 @@ public abstract class Json {
         }
 
         public <A> List<A> mapOpt(Function<JValue, Optional<A>> f) {
-            return this.value.stream().flatMap(f.andThen(Optional::stream)).collect(Collectors.toUnmodifiableList());
+            return this.value.stream().flatMap(f.andThen(Optional::stream)).toList();
         }
 
         public <A> List<A> mapToList(Function<JValue, A> f) {
-            return value.stream().map(f).collect(Collectors.toUnmodifiableList());
+            return value.stream().map(f).toList();
         }
 
         public JArray map(Function<JValue, JValue> f) {
@@ -762,7 +806,7 @@ public abstract class Json {
         }
 
         public <A> List<A> flatMapToList(Function<JValue, List<A>> f) {
-            return value.stream().flatMap(f.andThen(List::stream)).collect(Collectors.toUnmodifiableList());
+            return value.stream().flatMap(f.andThen(List::stream)).toList();
         }
 
         public int size() {
@@ -770,7 +814,7 @@ public abstract class Json {
         }
 
         public JArray append(JValue toAdd) {
-            List<JValue> list = Stream.concat(value.stream(), Stream.of(toAdd)).collect(Collectors.toUnmodifiableList());
+            List<JValue> list = Stream.concat(value.stream(), Stream.of(toAdd)).toList();
             return new JArray(list);
         }
 
@@ -804,7 +848,7 @@ public abstract class Json {
 
 
         public JArray prepend(JValue toAdd) {
-            List<JValue> list = Stream.concat(Stream.of(toAdd), value.stream()).collect(Collectors.toUnmodifiableList());
+            List<JValue> list = Stream.concat(Stream.of(toAdd), value.stream()).toList();
             return new JArray(list);
         }
 
@@ -870,15 +914,14 @@ public abstract class Json {
         }
 
         public JArray concat(JArray other) {
-            return new JArray(Stream.concat(this.value.stream(), other.stream()).collect(Collectors.toUnmodifiableList()));
+            return new JArray(Stream.concat(this.value.stream(), other.stream()).toList());
         }
     }
 
-    public static final class JObject extends JValue implements Iterable<Map.Entry<String, JValue>> {
+    public record JObject(Map<String, JValue> value) implements JValue, Iterable<Map.Entry<String, JValue>> {
         public static final Collector<Entry<String, JValue>, ?, Map<String, JValue>> MapCollector = Collectors.toUnmodifiableMap(Entry::getKey, Entry::getValue);
-        public final Map<String, JValue> value;
 
-        private JObject(Map<String, JValue> value) {
+        public JObject(Map<String, JValue> value) {
             this.value = Objects.requireNonNull(value, "You may not supply a null Map to JObject");
         }
 
@@ -897,19 +940,17 @@ public abstract class Json {
 
         @Override
         public String toString() {
-            return "JObject{" +
-                    "value=" + value +
-                    '}';
+            return "JObject{" + "value=" + value + "}";
         }
 
         @Override
-        public <X> X fold(Function<JString, X> fString, Function<JBoolean, X> fBoolean, Function<JNumber, X> fNumber, Function<JObject, X> fObject, Function<JArray, X> fArray, Supplier<X> fNull) {
-            return fObject.apply(this);
+        public <X> X fold(Folder<X> f) {
+            return f.onObject(this);
         }
 
         @Override
-        public void foldUnit(Consumer<JString> fString, Consumer<JBoolean> fBoolean, Consumer<JNumber> fNumber, Consumer<JObject> fObject, Consumer<JArray> fArray, Runnable fNull) {
-            fObject.accept(this);
+        public void foldUnit(VoidFolder f) {
+            f.onObject(this);
         }
 
         public Map<String, JValue> getValue() {
@@ -1007,9 +1048,7 @@ public abstract class Json {
         }
 
         public <B> List<B> mapToList(BiFunction<String, JValue, B> f) {
-            return value.entrySet().stream().map(
-                    e -> f.apply(e.getKey(), e.getValue())
-            ).collect(Collectors.toUnmodifiableList());
+            return value.entrySet().stream().map(e -> f.apply(e.getKey(), e.getValue())).collect(Collectors.toUnmodifiableList());
         }
 
         public <B> List<B> mapValues(Function<JValue, B> f) {

--- a/ast/src/main/java/net/hamnaberg/json/Json.java
+++ b/ast/src/main/java/net/hamnaberg/json/Json.java
@@ -386,6 +386,16 @@ public abstract class Json {
         default String pretty(PrettyPrinter p) {
             return p.writeString(this);
         }
+
+        /**
+         * Can emit directly to an Appendable without having to realize a String
+         *
+         * @param p          the pretty printer
+         * @param appendable for instance a Writer instance
+         */
+        default void writeTo(PrettyPrinter p, Appendable appendable) {
+            p.writeTo(this, appendable);
+        }
     }
 
     public sealed interface JScalarValue extends JValue permits JNull, JBoolean, JNumber, JString {

--- a/ast/src/main/java/net/hamnaberg/json/Json.java
+++ b/ast/src/main/java/net/hamnaberg/json/Json.java
@@ -223,179 +223,6 @@ public abstract class Json {
         return map;
     }
 
-    private static <A, B> Function<A, Optional<B>> emptyOption() {
-        return (ignore) -> Optional.empty();
-    }
-
-    public interface Folder<A> {
-        A onNull();
-
-        A onBoolean(JBoolean b);
-
-        A onNumber(JNumber n);
-
-        A onString(JString s);
-
-        A onArray(JArray a);
-
-        A onObject(JObject o);
-
-        default VoidFolder toVoid() {
-            var self = this;
-            return new VoidFolder() {
-                @Override
-                public void onNull() {
-                    self.onNull();
-                }
-
-                @Override
-                public void onBoolean(JBoolean b) {
-                    self.onBoolean(b);
-                }
-
-                @Override
-                public void onNumber(JNumber n) {
-                    self.onNumber(n);
-                }
-
-                @Override
-                public void onString(JString s) {
-                    self.onString(s);
-                }
-
-                @Override
-                public void onArray(JArray a) {
-                    self.onArray(a);
-                }
-
-                @Override
-                public void onObject(JObject o) {
-                    self.onObject(o);
-                }
-            };
-        }
-
-        static <X> Folder<X> from(Function<JString, X> fString, Function<JBoolean, X> fBoolean, Function<JNumber, X> fNumber, Function<JObject, X> fObject, Function<JArray, X> fArray, Supplier<X> fNull) {
-            return new Folder<>() {
-                @Override
-                public X onNull() {
-                    return fNull.get();
-                }
-
-                @Override
-                public X onBoolean(JBoolean b) {
-                    return fBoolean.apply(b);
-                }
-
-                @Override
-                public X onNumber(JNumber n) {
-                    return fNumber.apply(n);
-                }
-
-                @Override
-                public X onString(JString s) {
-                    return fString.apply(s);
-                }
-
-                @Override
-                public X onArray(JArray a) {
-                    return fArray.apply(a);
-                }
-
-                @Override
-                public X onObject(JObject o) {
-                    return fObject.apply(o);
-                }
-            };
-        }
-    }
-
-    public static class OptionalFolder<A> implements Folder<Optional<A>> {
-        @Override
-        public Optional<A> onNull() {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<A> onBoolean(JBoolean b) {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<A> onNumber(JNumber n) {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<A> onString(JString s) {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<A> onArray(JArray a) {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<A> onObject(JObject o) {
-            return Optional.empty();
-        }
-    }
-
-    public interface VoidFolder {
-        default void onNull() {
-        }
-
-        default void onBoolean(JBoolean b) {
-        }
-
-        default void onNumber(JNumber n) {
-        }
-
-        default void onString(JString s) {
-        }
-
-        default void onArray(JArray a) {
-        }
-
-        default void onObject(JObject o) {
-        }
-
-        static VoidFolder from(Consumer<JString> fString, Consumer<JBoolean> fBoolean, Consumer<JNumber> fNumber, Consumer<JObject> fObject, Consumer<JArray> fArray, Runnable fNull) {
-            return new VoidFolder() {
-                @Override
-                public void onNull() {
-                    fNull.run();
-                }
-
-                @Override
-                public void onBoolean(JBoolean b) {
-                    fBoolean.accept(b);
-                }
-
-                @Override
-                public void onNumber(JNumber n) {
-                    fNumber.accept(n);
-                }
-
-                @Override
-                public void onString(JString s) {
-                    fString.accept(s);
-                }
-
-                @Override
-                public void onArray(JArray a) {
-                    fArray.accept(a);
-                }
-
-                @Override
-                public void onObject(JObject o) {
-                    fObject.accept(o);
-                }
-            };
-        }
-    }
-
     public sealed interface JValue extends Serializable permits JNull, JBoolean, JNumber, JString, JObject, JArray {
 
         /**
@@ -638,7 +465,7 @@ public abstract class Json {
 
         @Override
         public String toString() {
-            return "JString{" + "value='" + value + "\"'}";
+            return "JString{value=\"" + value + "\"}";
         }
 
         @Override
@@ -659,7 +486,7 @@ public abstract class Json {
     public record JBoolean(boolean value) implements JValue {
         @Override
         public String toString() {
-            return "JBoolean{" + "value=" + value + "}";
+            return "JBoolean{value=" + value + "}";
         }
 
         @Override
@@ -704,7 +531,7 @@ public abstract class Json {
 
         @Override
         public String toString() {
-            return "JNumber{" + "value=" + value + "}";
+            return "JNumber{value=" + value + "}";
         }
 
         @Override
@@ -742,7 +569,7 @@ public abstract class Json {
 
         @Override
         public String toString() {
-            return "JArray{" + "value=" + value + "}";
+            return "JArray{value=" + value + "}";
         }
 
         @Override
@@ -940,7 +767,7 @@ public abstract class Json {
 
         @Override
         public String toString() {
-            return "JObject{" + "value=" + value + "}";
+            return "JObject{value=" + value + "}";
         }
 
         @Override

--- a/ast/src/main/java/net/hamnaberg/json/Json.java
+++ b/ast/src/main/java/net/hamnaberg/json/Json.java
@@ -1,12 +1,9 @@
 package net.hamnaberg.json;
 
 
-import java.util.Map.Entry;
-
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.*;
-import java.util.Iterator;
 import java.util.function.*;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
@@ -100,15 +97,15 @@ public abstract class Json {
     }
 
     @SafeVarargs
-    public static JObject jObject(Entry<String, JValue> first, Entry<String, JValue>... list) {
+    public static JObject jObject(Map.Entry<String, JValue> first, Map.Entry<String, JValue>... list) {
         LinkedHashMap<String, JValue> map = new LinkedHashMap<>(Map.of(first.getKey(), first.getValue()));
-        for (Entry<String, JValue> kv : list) {
+        for (Map.Entry<String, JValue> kv : list) {
             map.put(kv.getKey(), kv.getValue());
         }
         return new JObject(map);
     }
 
-    public static JObject jObject(Iterable<Entry<String, JValue>> value) {
+    public static JObject jObject(Iterable<Map.Entry<String, JValue>> value) {
         if (value instanceof JObject) {
             return (JObject) value;
         }
@@ -215,9 +212,9 @@ public abstract class Json {
         return tuple(name, Optional.ofNullable(value));
     }
 
-    private static LinkedHashMap<String, JValue> copyOf(Iterable<Entry<String, JValue>> value) {
+    private static LinkedHashMap<String, JValue> copyOf(Iterable<Map.Entry<String, JValue>> value) {
         LinkedHashMap<String, JValue> map = new LinkedHashMap<>();
-        for (Entry<String, JValue> kv : value) {
+        for (Map.Entry<String, JValue> kv : value) {
             map.put(kv.getKey(), kv.getValue());
         }
         return map;
@@ -702,7 +699,7 @@ public abstract class Json {
     }
 
     public record JObject(Map<String, JValue> value) implements JValue, Iterable<Map.Entry<String, JValue>> {
-        public static final Collector<Entry<String, JValue>, ?, Map<String, JValue>> MapCollector = Collectors.toUnmodifiableMap(Entry::getKey, Entry::getValue);
+        public static final Collector<Map.Entry<String, JValue>, ?, Map<String, JValue>> MapCollector = Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue);
 
         public JObject(Map<String, JValue> value) {
             this.value = Objects.requireNonNull(value, "You may not supply a null Map to JObject");
@@ -831,11 +828,11 @@ public abstract class Json {
         }
 
         public <B> List<B> mapToList(BiFunction<String, JValue, B> f) {
-            return value.entrySet().stream().map(e -> f.apply(e.getKey(), e.getValue())).collect(Collectors.toUnmodifiableList());
+            return value.entrySet().stream().map(e -> f.apply(e.getKey(), e.getValue())).toList();
         }
 
         public <B> List<B> mapValues(Function<JValue, B> f) {
-            return values().stream().map(f).collect(Collectors.toUnmodifiableList());
+            return values().stream().map(f).toList();
         }
 
         public JValue getOrDefault(String key, JValue defaultValue) {

--- a/ast/src/main/java/net/hamnaberg/json/OptionalFolder.java
+++ b/ast/src/main/java/net/hamnaberg/json/OptionalFolder.java
@@ -1,0 +1,35 @@
+package net.hamnaberg.json;
+
+import java.util.Optional;
+
+public class OptionalFolder<A> implements Folder<Optional<A>> {
+    @Override
+    public Optional<A> onNull() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<A> onBoolean(Json.JBoolean b) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<A> onNumber(Json.JNumber n) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<A> onString(Json.JString s) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<A> onArray(Json.JArray a) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<A> onObject(Json.JObject o) {
+        return Optional.empty();
+    }
+}

--- a/ast/src/main/java/net/hamnaberg/json/PrettyPrinter.java
+++ b/ast/src/main/java/net/hamnaberg/json/PrettyPrinter.java
@@ -84,7 +84,7 @@ public final class PrettyPrinter {
         }
     }
 
-    private class PrinterStateFolder implements Json.VoidFolder {
+    private class PrinterStateFolder implements VoidFolder {
         private final PrinterState state;
         private final char[] indents;
 

--- a/ast/src/main/java/net/hamnaberg/json/PrettyPrinter.java
+++ b/ast/src/main/java/net/hamnaberg/json/PrettyPrinter.java
@@ -2,6 +2,7 @@ package net.hamnaberg.json;
 
 
 import java.io.IOException;
+import java.nio.CharBuffer;
 import java.util.Map;
 
 public final class PrettyPrinter {
@@ -91,7 +92,7 @@ public final class PrettyPrinter {
 
         void append(char[] chars, int i, int length) {
             try {
-                appendable.append(new String(chars), i, length);
+                appendable.append(CharBuffer.wrap(chars), i, length);
             } catch (IOException e) {
                 throw new JsonWriteException("Unable to append to writer", e);
             }

--- a/ast/src/main/java/net/hamnaberg/json/VoidFolder.java
+++ b/ast/src/main/java/net/hamnaberg/json/VoidFolder.java
@@ -1,0 +1,57 @@
+package net.hamnaberg.json;
+
+import java.util.function.Consumer;
+
+public interface VoidFolder {
+    default void onNull() {
+    }
+
+    default void onBoolean(Json.JBoolean b) {
+    }
+
+    default void onNumber(Json.JNumber n) {
+    }
+
+    default void onString(Json.JString s) {
+    }
+
+    default void onArray(Json.JArray a) {
+    }
+
+    default void onObject(Json.JObject o) {
+    }
+
+    static VoidFolder from(Consumer<Json.JString> fString, Consumer<Json.JBoolean> fBoolean, Consumer<Json.JNumber> fNumber, Consumer<Json.JObject> fObject, Consumer<Json.JArray> fArray, Runnable fNull) {
+        return new VoidFolder() {
+            @Override
+            public void onNull() {
+                fNull.run();
+            }
+
+            @Override
+            public void onBoolean(Json.JBoolean b) {
+                fBoolean.accept(b);
+            }
+
+            @Override
+            public void onNumber(Json.JNumber n) {
+                fNumber.accept(n);
+            }
+
+            @Override
+            public void onString(Json.JString s) {
+                fString.accept(s);
+            }
+
+            @Override
+            public void onArray(Json.JArray a) {
+                fArray.accept(a);
+            }
+
+            @Override
+            public void onObject(Json.JObject o) {
+                fObject.accept(o);
+            }
+        };
+    }
+}

--- a/ast/src/test/java/net/hamnaberg/json/JValueTest.java
+++ b/ast/src/test/java/net/hamnaberg/json/JValueTest.java
@@ -41,8 +41,8 @@ public class JValueTest {
     public void JBoolean() {
         Json.JBoolean tru = Json.jBoolean(true);
         Json.JBoolean fals = Json.jBoolean(false);
-        assertTrue(tru.value);
-        assertFalse(fals.value);
+        assertTrue(tru.value());
+        assertFalse(fals.value());
         assertNotEquals(tru, fals);
         assertEquals("true", tru.scalarToString().orElse(""));
         assertEquals("false", fals.scalarToString().orElse(""));

--- a/ast/src/test/java/net/hamnaberg/json/JValueTest.java
+++ b/ast/src/test/java/net/hamnaberg/json/JValueTest.java
@@ -17,7 +17,7 @@ public class JValueTest {
         assertEquals(expected, Json.jNumber(20.0));
         assertTrue(expected.isNumber());
         assertTrue(expected.isScalar());
-        assertEquals("20", expected.scalarToString().orElse(""));
+        assertEquals("20", expected.scalarToString());
     }
 
     @Test
@@ -25,7 +25,7 @@ public class JValueTest {
         Json.JString string = Json.jString("Hello");
         assertTrue(string.isString());
         assertTrue(string.isScalar());
-        assertEquals("Hello", string.scalarToString().orElse(""));
+        assertEquals("Hello", string.scalarToString());
     }
 
     @Test
@@ -34,18 +34,18 @@ public class JValueTest {
         assertTrue(nullable.isNull());
         assertTrue(nullable.isScalar());
         assertFalse(nullable.isString());
-        assertEquals("null", nullable.scalarToString().orElse(""));
+        assertEquals("null", nullable.scalarToString());
     }
 
     @Test
     public void JBoolean() {
-        Json.JBoolean tru = Json.jBoolean(true);
-        Json.JBoolean fals = Json.jBoolean(false);
-        assertTrue(tru.value());
-        assertFalse(fals.value());
-        assertNotEquals(tru, fals);
-        assertEquals("true", tru.scalarToString().orElse(""));
-        assertEquals("false", fals.scalarToString().orElse(""));
+        Json.JBoolean truthy = Json.jBoolean(true);
+        Json.JBoolean falsy = Json.jBoolean(false);
+        assertTrue(truthy.value());
+        assertFalse(falsy.value());
+        assertNotEquals(truthy, falsy);
+        assertEquals("true", truthy.scalarToString());
+        assertEquals("false", falsy.scalarToString());
     }
 
     @Test

--- a/ast/src/test/java/net/hamnaberg/json/JsonTest.java
+++ b/ast/src/test/java/net/hamnaberg/json/JsonTest.java
@@ -16,7 +16,7 @@ public class JsonTest {
         Json.JString hello = Json.jString("hello");
         assertEquals("hello", hello.getValue());
         assertEquals(hello, Json.jString("hello"));
-        assertNotEquals(hello.toString(), Json.jString("hello").value);
+        assertNotEquals(hello.toString(), Json.jString("hello").value());
     }
 
     @Test
@@ -37,9 +37,9 @@ public class JsonTest {
         Json.JBoolean no = Json.jBoolean(false);
         assertEquals(yes, Json.jBoolean(true));
         assertEquals(no, Json.jBoolean(false));
-        assertNotEquals(yes.value, no.value);
-        assertEquals(yes.value, true);
-        assertEquals(no.value, false);
+        assertNotEquals(yes.value(), no.value());
+        assertTrue(yes.value());
+        assertFalse(no.value());
     }
 
     @Test

--- a/codec/pom.xml
+++ b/codec/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>net.hamnaberg</groupId>
       <artifactId>arities</artifactId>
-      <version>0.5.0</version>
+      <version>0.6.0-RC1</version>
     </dependency>
   </dependencies>
 </project>

--- a/codec/src/main/java/net/hamnaberg/json/codec/Encoders.java
+++ b/codec/src/main/java/net/hamnaberg/json/codec/Encoders.java
@@ -58,8 +58,8 @@ public abstract class Encoders {
 
     public static <A1, A2> EncodeJson<Tuple2<A1, A2>> encode(FieldEncoder<A1> e1, FieldEncoder<A2> e2) {
         return tuple -> Json.jObject(
-                Json.tuple(e1.name, e1.toJson(tuple._1)),
-                Json.tuple(e2.name, e2.toJson(tuple._2))
+                Json.tuple(e1.name, e1.toJson(tuple._1())),
+                Json.tuple(e2.name, e2.toJson(tuple._2()))
         );
     }
 
@@ -69,9 +69,9 @@ public abstract class Encoders {
 
     public static <A1, A2, A3> EncodeJson<Tuple3<A1, A2, A3>> encode(FieldEncoder<A1> e1, FieldEncoder<A2> e2, FieldEncoder<A3> e3) {
         return tuple -> Json.jObject(
-                Json.tuple(e1.name, e1.toJson(tuple._1)),
-                Json.tuple(e2.name, e2.toJson(tuple._2)),
-                Json.tuple(e3.name, e3.toJson(tuple._3))
+                Json.tuple(e1.name, e1.toJson(tuple._1())),
+                Json.tuple(e2.name, e2.toJson(tuple._2())),
+                Json.tuple(e3.name, e3.toJson(tuple._3()))
         );
     }
 
@@ -81,10 +81,10 @@ public abstract class Encoders {
 
     public static <A1, A2, A3, A4> EncodeJson<Tuple4<A1, A2, A3, A4>> encode(FieldEncoder<A1> e1, FieldEncoder<A2> e2, FieldEncoder<A3> e3, FieldEncoder<A4> e4) {
         return tuple -> Json.jObject(
-                Json.tuple(e1.name, e1.toJson(tuple._1)),
-                Json.tuple(e2.name, e2.toJson(tuple._2)),
-                Json.tuple(e3.name, e3.toJson(tuple._3)),
-                Json.tuple(e4.name, e4.toJson(tuple._4))
+                Json.tuple(e1.name, e1.toJson(tuple._1())),
+                Json.tuple(e2.name, e2.toJson(tuple._2())),
+                Json.tuple(e3.name, e3.toJson(tuple._3())),
+                Json.tuple(e4.name, e4.toJson(tuple._4()))
         );
     }
 
@@ -94,11 +94,11 @@ public abstract class Encoders {
 
     public static <A1, A2, A3, A4, A5> EncodeJson<Tuple5<A1, A2, A3, A4, A5>> encode(FieldEncoder<A1> e1, FieldEncoder<A2> e2, FieldEncoder<A3> e3, FieldEncoder<A4> e4, FieldEncoder<A5> e5) {
         return tuple -> Json.jObject(
-                Json.tuple(e1.name, e1.toJson(tuple._1)),
-                Json.tuple(e2.name, e2.toJson(tuple._2)),
-                Json.tuple(e3.name, e3.toJson(tuple._3)),
-                Json.tuple(e4.name, e4.toJson(tuple._4)),
-                Json.tuple(e5.name, e5.toJson(tuple._5))
+                Json.tuple(e1.name, e1.toJson(tuple._1())),
+                Json.tuple(e2.name, e2.toJson(tuple._2())),
+                Json.tuple(e3.name, e3.toJson(tuple._3())),
+                Json.tuple(e4.name, e4.toJson(tuple._4())),
+                Json.tuple(e5.name, e5.toJson(tuple._5()))
         );
     }
 
@@ -108,12 +108,12 @@ public abstract class Encoders {
 
     public static <A1, A2, A3, A4, A5, A6> EncodeJson<Tuple6<A1, A2, A3, A4, A5, A6>> encode(FieldEncoder<A1> e1, FieldEncoder<A2> e2, FieldEncoder<A3> e3, FieldEncoder<A4> e4, FieldEncoder<A5> e5, FieldEncoder<A6> e6) {
         return tuple -> Json.jObject(
-                Json.tuple(e1.name, e1.toJson(tuple._1)),
-                Json.tuple(e2.name, e2.toJson(tuple._2)),
-                Json.tuple(e3.name, e3.toJson(tuple._3)),
-                Json.tuple(e4.name, e4.toJson(tuple._4)),
-                Json.tuple(e5.name, e5.toJson(tuple._5)),
-                Json.tuple(e6.name, e6.toJson(tuple._6))
+                Json.tuple(e1.name, e1.toJson(tuple._1())),
+                Json.tuple(e2.name, e2.toJson(tuple._2())),
+                Json.tuple(e3.name, e3.toJson(tuple._3())),
+                Json.tuple(e4.name, e4.toJson(tuple._4())),
+                Json.tuple(e5.name, e5.toJson(tuple._5())),
+                Json.tuple(e6.name, e6.toJson(tuple._6()))
         );
     }
 
@@ -123,13 +123,13 @@ public abstract class Encoders {
 
     public static <A1, A2, A3, A4, A5, A6, A7> EncodeJson<Tuple7<A1, A2, A3, A4, A5, A6, A7>> encode(FieldEncoder<A1> e1, FieldEncoder<A2> e2, FieldEncoder<A3> e3, FieldEncoder<A4> e4, FieldEncoder<A5> e5, FieldEncoder<A6> e6, FieldEncoder<A7> e7) {
         return tuple -> Json.jObject(
-                Json.tuple(e1.name, e1.toJson(tuple._1)),
-                Json.tuple(e2.name, e2.toJson(tuple._2)),
-                Json.tuple(e3.name, e3.toJson(tuple._3)),
-                Json.tuple(e4.name, e4.toJson(tuple._4)),
-                Json.tuple(e5.name, e5.toJson(tuple._5)),
-                Json.tuple(e6.name, e6.toJson(tuple._6)),
-                Json.tuple(e7.name, e7.toJson(tuple._7))
+                Json.tuple(e1.name, e1.toJson(tuple._1())),
+                Json.tuple(e2.name, e2.toJson(tuple._2())),
+                Json.tuple(e3.name, e3.toJson(tuple._3())),
+                Json.tuple(e4.name, e4.toJson(tuple._4())),
+                Json.tuple(e5.name, e5.toJson(tuple._5())),
+                Json.tuple(e6.name, e6.toJson(tuple._6())),
+                Json.tuple(e7.name, e7.toJson(tuple._7()))
         );
     }
 
@@ -139,14 +139,14 @@ public abstract class Encoders {
 
     public static <A1, A2, A3, A4, A5, A6, A7, A8> EncodeJson<Tuple8<A1, A2, A3, A4, A5, A6, A7, A8>> encode(FieldEncoder<A1> e1, FieldEncoder<A2> e2, FieldEncoder<A3> e3, FieldEncoder<A4> e4, FieldEncoder<A5> e5, FieldEncoder<A6> e6, FieldEncoder<A7> e7, FieldEncoder<A8> e8) {
         return tuple -> Json.jObject(
-                Json.tuple(e1.name, e1.toJson(tuple._1)),
-                Json.tuple(e2.name, e2.toJson(tuple._2)),
-                Json.tuple(e3.name, e3.toJson(tuple._3)),
-                Json.tuple(e4.name, e4.toJson(tuple._4)),
-                Json.tuple(e5.name, e5.toJson(tuple._5)),
-                Json.tuple(e6.name, e6.toJson(tuple._6)),
-                Json.tuple(e7.name, e7.toJson(tuple._7)),
-                Json.tuple(e8.name, e8.toJson(tuple._8))
+                Json.tuple(e1.name, e1.toJson(tuple._1())),
+                Json.tuple(e2.name, e2.toJson(tuple._2())),
+                Json.tuple(e3.name, e3.toJson(tuple._3())),
+                Json.tuple(e4.name, e4.toJson(tuple._4())),
+                Json.tuple(e5.name, e5.toJson(tuple._5())),
+                Json.tuple(e6.name, e6.toJson(tuple._6())),
+                Json.tuple(e7.name, e7.toJson(tuple._7())),
+                Json.tuple(e8.name, e8.toJson(tuple._8()))
         );
     }
 
@@ -156,15 +156,15 @@ public abstract class Encoders {
 
     public static <A1, A2, A3, A4, A5, A6, A7, A8, A9> EncodeJson<Tuple9<A1, A2, A3, A4, A5, A6, A7, A8, A9>> encode(FieldEncoder<A1> e1, FieldEncoder<A2> e2, FieldEncoder<A3> e3, FieldEncoder<A4> e4, FieldEncoder<A5> e5, FieldEncoder<A6> e6, FieldEncoder<A7> e7, FieldEncoder<A8> e8, FieldEncoder<A9> e9) {
         return tuple -> Json.jObject(
-                Json.tuple(e1.name, e1.toJson(tuple._1)),
-                Json.tuple(e2.name, e2.toJson(tuple._2)),
-                Json.tuple(e3.name, e3.toJson(tuple._3)),
-                Json.tuple(e4.name, e4.toJson(tuple._4)),
-                Json.tuple(e5.name, e5.toJson(tuple._5)),
-                Json.tuple(e6.name, e6.toJson(tuple._6)),
-                Json.tuple(e7.name, e7.toJson(tuple._7)),
-                Json.tuple(e8.name, e8.toJson(tuple._8)),
-                Json.tuple(e9.name, e9.toJson(tuple._9))
+                Json.tuple(e1.name, e1.toJson(tuple._1())),
+                Json.tuple(e2.name, e2.toJson(tuple._2())),
+                Json.tuple(e3.name, e3.toJson(tuple._3())),
+                Json.tuple(e4.name, e4.toJson(tuple._4())),
+                Json.tuple(e5.name, e5.toJson(tuple._5())),
+                Json.tuple(e6.name, e6.toJson(tuple._6())),
+                Json.tuple(e7.name, e7.toJson(tuple._7())),
+                Json.tuple(e8.name, e8.toJson(tuple._8())),
+                Json.tuple(e9.name, e9.toJson(tuple._9()))
         );
     }
 
@@ -174,16 +174,16 @@ public abstract class Encoders {
 
     public static <A1, A2, A3, A4, A5, A6, A7, A8, A9, A10> EncodeJson<Tuple10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10>> encode(FieldEncoder<A1> e1, FieldEncoder<A2> e2, FieldEncoder<A3> e3, FieldEncoder<A4> e4, FieldEncoder<A5> e5, FieldEncoder<A6> e6, FieldEncoder<A7> e7, FieldEncoder<A8> e8, FieldEncoder<A9> e9, FieldEncoder<A10> e10) {
         return tuple -> Json.jObject(
-                Json.tuple(e1.name, e1.toJson(tuple._1)),
-                Json.tuple(e2.name, e2.toJson(tuple._2)),
-                Json.tuple(e3.name, e3.toJson(tuple._3)),
-                Json.tuple(e4.name, e4.toJson(tuple._4)),
-                Json.tuple(e5.name, e5.toJson(tuple._5)),
-                Json.tuple(e6.name, e6.toJson(tuple._6)),
-                Json.tuple(e7.name, e7.toJson(tuple._7)),
-                Json.tuple(e8.name, e8.toJson(tuple._8)),
-                Json.tuple(e9.name, e9.toJson(tuple._9)),
-                Json.tuple(e10.name, e10.toJson(tuple._10))
+                Json.tuple(e1.name, e1.toJson(tuple._1())),
+                Json.tuple(e2.name, e2.toJson(tuple._2())),
+                Json.tuple(e3.name, e3.toJson(tuple._3())),
+                Json.tuple(e4.name, e4.toJson(tuple._4())),
+                Json.tuple(e5.name, e5.toJson(tuple._5())),
+                Json.tuple(e6.name, e6.toJson(tuple._6())),
+                Json.tuple(e7.name, e7.toJson(tuple._7())),
+                Json.tuple(e8.name, e8.toJson(tuple._8())),
+                Json.tuple(e9.name, e9.toJson(tuple._9())),
+                Json.tuple(e10.name, e10.toJson(tuple._10()))
         );
     }
 
@@ -193,17 +193,17 @@ public abstract class Encoders {
 
     public static <A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11> EncodeJson<Tuple11<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11>> encode(FieldEncoder<A1> e1, FieldEncoder<A2> e2, FieldEncoder<A3> e3, FieldEncoder<A4> e4, FieldEncoder<A5> e5, FieldEncoder<A6> e6, FieldEncoder<A7> e7, FieldEncoder<A8> e8, FieldEncoder<A9> e9, FieldEncoder<A10> e10, FieldEncoder<A11> e11) {
         return tuple -> Json.jObject(
-                Json.tuple(e1.name, e1.toJson(tuple._1)),
-                Json.tuple(e2.name, e2.toJson(tuple._2)),
-                Json.tuple(e3.name, e3.toJson(tuple._3)),
-                Json.tuple(e4.name, e4.toJson(tuple._4)),
-                Json.tuple(e5.name, e5.toJson(tuple._5)),
-                Json.tuple(e6.name, e6.toJson(tuple._6)),
-                Json.tuple(e7.name, e7.toJson(tuple._7)),
-                Json.tuple(e8.name, e8.toJson(tuple._8)),
-                Json.tuple(e9.name, e9.toJson(tuple._9)),
-                Json.tuple(e10.name, e10.toJson(tuple._10)),
-                Json.tuple(e11.name, e11.toJson(tuple._11))
+                Json.tuple(e1.name, e1.toJson(tuple._1())),
+                Json.tuple(e2.name, e2.toJson(tuple._2())),
+                Json.tuple(e3.name, e3.toJson(tuple._3())),
+                Json.tuple(e4.name, e4.toJson(tuple._4())),
+                Json.tuple(e5.name, e5.toJson(tuple._5())),
+                Json.tuple(e6.name, e6.toJson(tuple._6())),
+                Json.tuple(e7.name, e7.toJson(tuple._7())),
+                Json.tuple(e8.name, e8.toJson(tuple._8())),
+                Json.tuple(e9.name, e9.toJson(tuple._9())),
+                Json.tuple(e10.name, e10.toJson(tuple._10())),
+                Json.tuple(e11.name, e11.toJson(tuple._11()))
         );
     }
 
@@ -213,18 +213,18 @@ public abstract class Encoders {
 
     public static <A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12> EncodeJson<Tuple12<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12>> encode(FieldEncoder<A1> e1, FieldEncoder<A2> e2, FieldEncoder<A3> e3, FieldEncoder<A4> e4, FieldEncoder<A5> e5, FieldEncoder<A6> e6, FieldEncoder<A7> e7, FieldEncoder<A8> e8, FieldEncoder<A9> e9, FieldEncoder<A10> e10, FieldEncoder<A11> e11, FieldEncoder<A12> e12) {
         return tuple -> Json.jObject(
-                Json.tuple(e1.name, e1.toJson(tuple._1)),
-                Json.tuple(e2.name, e2.toJson(tuple._2)),
-                Json.tuple(e3.name, e3.toJson(tuple._3)),
-                Json.tuple(e4.name, e4.toJson(tuple._4)),
-                Json.tuple(e5.name, e5.toJson(tuple._5)),
-                Json.tuple(e6.name, e6.toJson(tuple._6)),
-                Json.tuple(e7.name, e7.toJson(tuple._7)),
-                Json.tuple(e8.name, e8.toJson(tuple._8)),
-                Json.tuple(e9.name, e9.toJson(tuple._9)),
-                Json.tuple(e10.name, e10.toJson(tuple._10)),
-                Json.tuple(e11.name, e11.toJson(tuple._11)),
-                Json.tuple(e12.name, e12.toJson(tuple._12))
+                Json.tuple(e1.name, e1.toJson(tuple._1())),
+                Json.tuple(e2.name, e2.toJson(tuple._2())),
+                Json.tuple(e3.name, e3.toJson(tuple._3())),
+                Json.tuple(e4.name, e4.toJson(tuple._4())),
+                Json.tuple(e5.name, e5.toJson(tuple._5())),
+                Json.tuple(e6.name, e6.toJson(tuple._6())),
+                Json.tuple(e7.name, e7.toJson(tuple._7())),
+                Json.tuple(e8.name, e8.toJson(tuple._8())),
+                Json.tuple(e9.name, e9.toJson(tuple._9())),
+                Json.tuple(e10.name, e10.toJson(tuple._10())),
+                Json.tuple(e11.name, e11.toJson(tuple._11())),
+                Json.tuple(e12.name, e12.toJson(tuple._12()))
         );
     }
 
@@ -234,19 +234,19 @@ public abstract class Encoders {
 
     public static <A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13> EncodeJson<Tuple13<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13>> encode(FieldEncoder<A1> e1, FieldEncoder<A2> e2, FieldEncoder<A3> e3, FieldEncoder<A4> e4, FieldEncoder<A5> e5, FieldEncoder<A6> e6, FieldEncoder<A7> e7, FieldEncoder<A8> e8, FieldEncoder<A9> e9, FieldEncoder<A10> e10, FieldEncoder<A11> e11, FieldEncoder<A12> e12, FieldEncoder<A13> e13) {
         return tuple -> Json.jObject(
-                Json.tuple(e1.name, e1.toJson(tuple._1)),
-                Json.tuple(e2.name, e2.toJson(tuple._2)),
-                Json.tuple(e3.name, e3.toJson(tuple._3)),
-                Json.tuple(e4.name, e4.toJson(tuple._4)),
-                Json.tuple(e5.name, e5.toJson(tuple._5)),
-                Json.tuple(e6.name, e6.toJson(tuple._6)),
-                Json.tuple(e7.name, e7.toJson(tuple._7)),
-                Json.tuple(e8.name, e8.toJson(tuple._8)),
-                Json.tuple(e9.name, e9.toJson(tuple._9)),
-                Json.tuple(e10.name, e10.toJson(tuple._10)),
-                Json.tuple(e11.name, e11.toJson(tuple._11)),
-                Json.tuple(e12.name, e12.toJson(tuple._12)),
-                Json.tuple(e13.name, e13.toJson(tuple._13))
+                Json.tuple(e1.name, e1.toJson(tuple._1())),
+                Json.tuple(e2.name, e2.toJson(tuple._2())),
+                Json.tuple(e3.name, e3.toJson(tuple._3())),
+                Json.tuple(e4.name, e4.toJson(tuple._4())),
+                Json.tuple(e5.name, e5.toJson(tuple._5())),
+                Json.tuple(e6.name, e6.toJson(tuple._6())),
+                Json.tuple(e7.name, e7.toJson(tuple._7())),
+                Json.tuple(e8.name, e8.toJson(tuple._8())),
+                Json.tuple(e9.name, e9.toJson(tuple._9())),
+                Json.tuple(e10.name, e10.toJson(tuple._10())),
+                Json.tuple(e11.name, e11.toJson(tuple._11())),
+                Json.tuple(e12.name, e12.toJson(tuple._12())),
+                Json.tuple(e13.name, e13.toJson(tuple._13()))
         );
     }
 
@@ -256,20 +256,20 @@ public abstract class Encoders {
 
     public static <A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14> EncodeJson<Tuple14<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14>> encode(FieldEncoder<A1> e1, FieldEncoder<A2> e2, FieldEncoder<A3> e3, FieldEncoder<A4> e4, FieldEncoder<A5> e5, FieldEncoder<A6> e6, FieldEncoder<A7> e7, FieldEncoder<A8> e8, FieldEncoder<A9> e9, FieldEncoder<A10> e10, FieldEncoder<A11> e11, FieldEncoder<A12> e12, FieldEncoder<A13> e13, FieldEncoder<A14> e14) {
         return tuple -> Json.jObject(
-                Json.tuple(e1.name, e1.toJson(tuple._1)),
-                Json.tuple(e2.name, e2.toJson(tuple._2)),
-                Json.tuple(e3.name, e3.toJson(tuple._3)),
-                Json.tuple(e4.name, e4.toJson(tuple._4)),
-                Json.tuple(e5.name, e5.toJson(tuple._5)),
-                Json.tuple(e6.name, e6.toJson(tuple._6)),
-                Json.tuple(e7.name, e7.toJson(tuple._7)),
-                Json.tuple(e8.name, e8.toJson(tuple._8)),
-                Json.tuple(e9.name, e9.toJson(tuple._9)),
-                Json.tuple(e10.name, e10.toJson(tuple._10)),
-                Json.tuple(e11.name, e11.toJson(tuple._11)),
-                Json.tuple(e12.name, e12.toJson(tuple._12)),
-                Json.tuple(e13.name, e13.toJson(tuple._13)),
-                Json.tuple(e14.name, e14.toJson(tuple._14))
+                Json.tuple(e1.name, e1.toJson(tuple._1())),
+                Json.tuple(e2.name, e2.toJson(tuple._2())),
+                Json.tuple(e3.name, e3.toJson(tuple._3())),
+                Json.tuple(e4.name, e4.toJson(tuple._4())),
+                Json.tuple(e5.name, e5.toJson(tuple._5())),
+                Json.tuple(e6.name, e6.toJson(tuple._6())),
+                Json.tuple(e7.name, e7.toJson(tuple._7())),
+                Json.tuple(e8.name, e8.toJson(tuple._8())),
+                Json.tuple(e9.name, e9.toJson(tuple._9())),
+                Json.tuple(e10.name, e10.toJson(tuple._10())),
+                Json.tuple(e11.name, e11.toJson(tuple._11())),
+                Json.tuple(e12.name, e12.toJson(tuple._12())),
+                Json.tuple(e13.name, e13.toJson(tuple._13())),
+                Json.tuple(e14.name, e14.toJson(tuple._14()))
         );
     }
 
@@ -279,21 +279,21 @@ public abstract class Encoders {
 
     public static <A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15> EncodeJson<Tuple15<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15>> encode(FieldEncoder<A1> e1, FieldEncoder<A2> e2, FieldEncoder<A3> e3, FieldEncoder<A4> e4, FieldEncoder<A5> e5, FieldEncoder<A6> e6, FieldEncoder<A7> e7, FieldEncoder<A8> e8, FieldEncoder<A9> e9, FieldEncoder<A10> e10, FieldEncoder<A11> e11, FieldEncoder<A12> e12, FieldEncoder<A13> e13, FieldEncoder<A14> e14, FieldEncoder<A15> e15) {
         return tuple -> Json.jObject(
-                Json.tuple(e1.name, e1.toJson(tuple._1)),
-                Json.tuple(e2.name, e2.toJson(tuple._2)),
-                Json.tuple(e3.name, e3.toJson(tuple._3)),
-                Json.tuple(e4.name, e4.toJson(tuple._4)),
-                Json.tuple(e5.name, e5.toJson(tuple._5)),
-                Json.tuple(e6.name, e6.toJson(tuple._6)),
-                Json.tuple(e7.name, e7.toJson(tuple._7)),
-                Json.tuple(e8.name, e8.toJson(tuple._8)),
-                Json.tuple(e9.name, e9.toJson(tuple._9)),
-                Json.tuple(e10.name, e10.toJson(tuple._10)),
-                Json.tuple(e11.name, e11.toJson(tuple._11)),
-                Json.tuple(e12.name, e12.toJson(tuple._12)),
-                Json.tuple(e13.name, e13.toJson(tuple._13)),
-                Json.tuple(e14.name, e14.toJson(tuple._14)),
-                Json.tuple(e15.name, e15.toJson(tuple._15))
+                Json.tuple(e1.name, e1.toJson(tuple._1())),
+                Json.tuple(e2.name, e2.toJson(tuple._2())),
+                Json.tuple(e3.name, e3.toJson(tuple._3())),
+                Json.tuple(e4.name, e4.toJson(tuple._4())),
+                Json.tuple(e5.name, e5.toJson(tuple._5())),
+                Json.tuple(e6.name, e6.toJson(tuple._6())),
+                Json.tuple(e7.name, e7.toJson(tuple._7())),
+                Json.tuple(e8.name, e8.toJson(tuple._8())),
+                Json.tuple(e9.name, e9.toJson(tuple._9())),
+                Json.tuple(e10.name, e10.toJson(tuple._10())),
+                Json.tuple(e11.name, e11.toJson(tuple._11())),
+                Json.tuple(e12.name, e12.toJson(tuple._12())),
+                Json.tuple(e13.name, e13.toJson(tuple._13())),
+                Json.tuple(e14.name, e14.toJson(tuple._14())),
+                Json.tuple(e15.name, e15.toJson(tuple._15()))
         );
     }
 
@@ -303,22 +303,22 @@ public abstract class Encoders {
 
     public static <A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16> EncodeJson<Tuple16<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16>> encode(FieldEncoder<A1> e1, FieldEncoder<A2> e2, FieldEncoder<A3> e3, FieldEncoder<A4> e4, FieldEncoder<A5> e5, FieldEncoder<A6> e6, FieldEncoder<A7> e7, FieldEncoder<A8> e8, FieldEncoder<A9> e9, FieldEncoder<A10> e10, FieldEncoder<A11> e11, FieldEncoder<A12> e12, FieldEncoder<A13> e13, FieldEncoder<A14> e14, FieldEncoder<A15> e15, FieldEncoder<A16> e16) {
         return tuple -> Json.jObject(
-                Json.tuple(e1.name, e1.toJson(tuple._1)),
-                Json.tuple(e2.name, e2.toJson(tuple._2)),
-                Json.tuple(e3.name, e3.toJson(tuple._3)),
-                Json.tuple(e4.name, e4.toJson(tuple._4)),
-                Json.tuple(e5.name, e5.toJson(tuple._5)),
-                Json.tuple(e6.name, e6.toJson(tuple._6)),
-                Json.tuple(e7.name, e7.toJson(tuple._7)),
-                Json.tuple(e8.name, e8.toJson(tuple._8)),
-                Json.tuple(e9.name, e9.toJson(tuple._9)),
-                Json.tuple(e10.name, e10.toJson(tuple._10)),
-                Json.tuple(e11.name, e11.toJson(tuple._11)),
-                Json.tuple(e12.name, e12.toJson(tuple._12)),
-                Json.tuple(e13.name, e13.toJson(tuple._13)),
-                Json.tuple(e14.name, e14.toJson(tuple._14)),
-                Json.tuple(e15.name, e15.toJson(tuple._15)),
-                Json.tuple(e16.name, e16.toJson(tuple._16))
+                Json.tuple(e1.name, e1.toJson(tuple._1())),
+                Json.tuple(e2.name, e2.toJson(tuple._2())),
+                Json.tuple(e3.name, e3.toJson(tuple._3())),
+                Json.tuple(e4.name, e4.toJson(tuple._4())),
+                Json.tuple(e5.name, e5.toJson(tuple._5())),
+                Json.tuple(e6.name, e6.toJson(tuple._6())),
+                Json.tuple(e7.name, e7.toJson(tuple._7())),
+                Json.tuple(e8.name, e8.toJson(tuple._8())),
+                Json.tuple(e9.name, e9.toJson(tuple._9())),
+                Json.tuple(e10.name, e10.toJson(tuple._10())),
+                Json.tuple(e11.name, e11.toJson(tuple._11())),
+                Json.tuple(e12.name, e12.toJson(tuple._12())),
+                Json.tuple(e13.name, e13.toJson(tuple._13())),
+                Json.tuple(e14.name, e14.toJson(tuple._14())),
+                Json.tuple(e15.name, e15.toJson(tuple._15())),
+                Json.tuple(e16.name, e16.toJson(tuple._16()))
         );
     }
 
@@ -328,23 +328,23 @@ public abstract class Encoders {
 
     public static <A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17> EncodeJson<Tuple17<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17>> encode(FieldEncoder<A1> e1, FieldEncoder<A2> e2, FieldEncoder<A3> e3, FieldEncoder<A4> e4, FieldEncoder<A5> e5, FieldEncoder<A6> e6, FieldEncoder<A7> e7, FieldEncoder<A8> e8, FieldEncoder<A9> e9, FieldEncoder<A10> e10, FieldEncoder<A11> e11, FieldEncoder<A12> e12, FieldEncoder<A13> e13, FieldEncoder<A14> e14, FieldEncoder<A15> e15, FieldEncoder<A16> e16, FieldEncoder<A17> e17) {
         return tuple -> Json.jObject(
-                Json.tuple(e1.name, e1.toJson(tuple._1)),
-                Json.tuple(e2.name, e2.toJson(tuple._2)),
-                Json.tuple(e3.name, e3.toJson(tuple._3)),
-                Json.tuple(e4.name, e4.toJson(tuple._4)),
-                Json.tuple(e5.name, e5.toJson(tuple._5)),
-                Json.tuple(e6.name, e6.toJson(tuple._6)),
-                Json.tuple(e7.name, e7.toJson(tuple._7)),
-                Json.tuple(e8.name, e8.toJson(tuple._8)),
-                Json.tuple(e9.name, e9.toJson(tuple._9)),
-                Json.tuple(e10.name, e10.toJson(tuple._10)),
-                Json.tuple(e11.name, e11.toJson(tuple._11)),
-                Json.tuple(e12.name, e12.toJson(tuple._12)),
-                Json.tuple(e13.name, e13.toJson(tuple._13)),
-                Json.tuple(e14.name, e14.toJson(tuple._14)),
-                Json.tuple(e15.name, e15.toJson(tuple._15)),
-                Json.tuple(e16.name, e16.toJson(tuple._16)),
-                Json.tuple(e17.name, e17.toJson(tuple._17))
+                Json.tuple(e1.name, e1.toJson(tuple._1())),
+                Json.tuple(e2.name, e2.toJson(tuple._2())),
+                Json.tuple(e3.name, e3.toJson(tuple._3())),
+                Json.tuple(e4.name, e4.toJson(tuple._4())),
+                Json.tuple(e5.name, e5.toJson(tuple._5())),
+                Json.tuple(e6.name, e6.toJson(tuple._6())),
+                Json.tuple(e7.name, e7.toJson(tuple._7())),
+                Json.tuple(e8.name, e8.toJson(tuple._8())),
+                Json.tuple(e9.name, e9.toJson(tuple._9())),
+                Json.tuple(e10.name, e10.toJson(tuple._10())),
+                Json.tuple(e11.name, e11.toJson(tuple._11())),
+                Json.tuple(e12.name, e12.toJson(tuple._12())),
+                Json.tuple(e13.name, e13.toJson(tuple._13())),
+                Json.tuple(e14.name, e14.toJson(tuple._14())),
+                Json.tuple(e15.name, e15.toJson(tuple._15())),
+                Json.tuple(e16.name, e16.toJson(tuple._16())),
+                Json.tuple(e17.name, e17.toJson(tuple._17()))
         );
     }
 
@@ -354,24 +354,24 @@ public abstract class Encoders {
 
     public static <A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18> EncodeJson<Tuple18<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18>> encode(FieldEncoder<A1> e1, FieldEncoder<A2> e2, FieldEncoder<A3> e3, FieldEncoder<A4> e4, FieldEncoder<A5> e5, FieldEncoder<A6> e6, FieldEncoder<A7> e7, FieldEncoder<A8> e8, FieldEncoder<A9> e9, FieldEncoder<A10> e10, FieldEncoder<A11> e11, FieldEncoder<A12> e12, FieldEncoder<A13> e13, FieldEncoder<A14> e14, FieldEncoder<A15> e15, FieldEncoder<A16> e16, FieldEncoder<A17> e17, FieldEncoder<A18> e18) {
         return tuple -> Json.jObject(
-                Json.tuple(e1.name, e1.toJson(tuple._1)),
-                Json.tuple(e2.name, e2.toJson(tuple._2)),
-                Json.tuple(e3.name, e3.toJson(tuple._3)),
-                Json.tuple(e4.name, e4.toJson(tuple._4)),
-                Json.tuple(e5.name, e5.toJson(tuple._5)),
-                Json.tuple(e6.name, e6.toJson(tuple._6)),
-                Json.tuple(e7.name, e7.toJson(tuple._7)),
-                Json.tuple(e8.name, e8.toJson(tuple._8)),
-                Json.tuple(e9.name, e9.toJson(tuple._9)),
-                Json.tuple(e10.name, e10.toJson(tuple._10)),
-                Json.tuple(e11.name, e11.toJson(tuple._11)),
-                Json.tuple(e12.name, e12.toJson(tuple._12)),
-                Json.tuple(e13.name, e13.toJson(tuple._13)),
-                Json.tuple(e14.name, e14.toJson(tuple._14)),
-                Json.tuple(e15.name, e15.toJson(tuple._15)),
-                Json.tuple(e16.name, e16.toJson(tuple._16)),
-                Json.tuple(e17.name, e17.toJson(tuple._17)),
-                Json.tuple(e18.name, e18.toJson(tuple._18))
+                Json.tuple(e1.name, e1.toJson(tuple._1())),
+                Json.tuple(e2.name, e2.toJson(tuple._2())),
+                Json.tuple(e3.name, e3.toJson(tuple._3())),
+                Json.tuple(e4.name, e4.toJson(tuple._4())),
+                Json.tuple(e5.name, e5.toJson(tuple._5())),
+                Json.tuple(e6.name, e6.toJson(tuple._6())),
+                Json.tuple(e7.name, e7.toJson(tuple._7())),
+                Json.tuple(e8.name, e8.toJson(tuple._8())),
+                Json.tuple(e9.name, e9.toJson(tuple._9())),
+                Json.tuple(e10.name, e10.toJson(tuple._10())),
+                Json.tuple(e11.name, e11.toJson(tuple._11())),
+                Json.tuple(e12.name, e12.toJson(tuple._12())),
+                Json.tuple(e13.name, e13.toJson(tuple._13())),
+                Json.tuple(e14.name, e14.toJson(tuple._14())),
+                Json.tuple(e15.name, e15.toJson(tuple._15())),
+                Json.tuple(e16.name, e16.toJson(tuple._16())),
+                Json.tuple(e17.name, e17.toJson(tuple._17())),
+                Json.tuple(e18.name, e18.toJson(tuple._18()))
         );
     }
 
@@ -381,25 +381,25 @@ public abstract class Encoders {
 
     public static <A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19> EncodeJson<Tuple19<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19>> encode(FieldEncoder<A1> e1, FieldEncoder<A2> e2, FieldEncoder<A3> e3, FieldEncoder<A4> e4, FieldEncoder<A5> e5, FieldEncoder<A6> e6, FieldEncoder<A7> e7, FieldEncoder<A8> e8, FieldEncoder<A9> e9, FieldEncoder<A10> e10, FieldEncoder<A11> e11, FieldEncoder<A12> e12, FieldEncoder<A13> e13, FieldEncoder<A14> e14, FieldEncoder<A15> e15, FieldEncoder<A16> e16, FieldEncoder<A17> e17, FieldEncoder<A18> e18, FieldEncoder<A19> e19) {
         return tuple -> Json.jObject(
-                Json.tuple(e1.name, e1.toJson(tuple._1)),
-                Json.tuple(e2.name, e2.toJson(tuple._2)),
-                Json.tuple(e3.name, e3.toJson(tuple._3)),
-                Json.tuple(e4.name, e4.toJson(tuple._4)),
-                Json.tuple(e5.name, e5.toJson(tuple._5)),
-                Json.tuple(e6.name, e6.toJson(tuple._6)),
-                Json.tuple(e7.name, e7.toJson(tuple._7)),
-                Json.tuple(e8.name, e8.toJson(tuple._8)),
-                Json.tuple(e9.name, e9.toJson(tuple._9)),
-                Json.tuple(e10.name, e10.toJson(tuple._10)),
-                Json.tuple(e11.name, e11.toJson(tuple._11)),
-                Json.tuple(e12.name, e12.toJson(tuple._12)),
-                Json.tuple(e13.name, e13.toJson(tuple._13)),
-                Json.tuple(e14.name, e14.toJson(tuple._14)),
-                Json.tuple(e15.name, e15.toJson(tuple._15)),
-                Json.tuple(e16.name, e16.toJson(tuple._16)),
-                Json.tuple(e17.name, e17.toJson(tuple._17)),
-                Json.tuple(e18.name, e18.toJson(tuple._18)),
-                Json.tuple(e19.name, e19.toJson(tuple._19))
+                Json.tuple(e1.name, e1.toJson(tuple._1())),
+                Json.tuple(e2.name, e2.toJson(tuple._2())),
+                Json.tuple(e3.name, e3.toJson(tuple._3())),
+                Json.tuple(e4.name, e4.toJson(tuple._4())),
+                Json.tuple(e5.name, e5.toJson(tuple._5())),
+                Json.tuple(e6.name, e6.toJson(tuple._6())),
+                Json.tuple(e7.name, e7.toJson(tuple._7())),
+                Json.tuple(e8.name, e8.toJson(tuple._8())),
+                Json.tuple(e9.name, e9.toJson(tuple._9())),
+                Json.tuple(e10.name, e10.toJson(tuple._10())),
+                Json.tuple(e11.name, e11.toJson(tuple._11())),
+                Json.tuple(e12.name, e12.toJson(tuple._12())),
+                Json.tuple(e13.name, e13.toJson(tuple._13())),
+                Json.tuple(e14.name, e14.toJson(tuple._14())),
+                Json.tuple(e15.name, e15.toJson(tuple._15())),
+                Json.tuple(e16.name, e16.toJson(tuple._16())),
+                Json.tuple(e17.name, e17.toJson(tuple._17())),
+                Json.tuple(e18.name, e18.toJson(tuple._18())),
+                Json.tuple(e19.name, e19.toJson(tuple._19()))
         );
     }
 
@@ -409,26 +409,26 @@ public abstract class Encoders {
 
     public static <A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20> EncodeJson<Tuple20<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20>> encode(FieldEncoder<A1> e1, FieldEncoder<A2> e2, FieldEncoder<A3> e3, FieldEncoder<A4> e4, FieldEncoder<A5> e5, FieldEncoder<A6> e6, FieldEncoder<A7> e7, FieldEncoder<A8> e8, FieldEncoder<A9> e9, FieldEncoder<A10> e10, FieldEncoder<A11> e11, FieldEncoder<A12> e12, FieldEncoder<A13> e13, FieldEncoder<A14> e14, FieldEncoder<A15> e15, FieldEncoder<A16> e16, FieldEncoder<A17> e17, FieldEncoder<A18> e18, FieldEncoder<A19> e19, FieldEncoder<A20> e20) {
         return tuple -> Json.jObject(
-                Json.tuple(e1.name, e1.toJson(tuple._1)),
-                Json.tuple(e2.name, e2.toJson(tuple._2)),
-                Json.tuple(e3.name, e3.toJson(tuple._3)),
-                Json.tuple(e4.name, e4.toJson(tuple._4)),
-                Json.tuple(e5.name, e5.toJson(tuple._5)),
-                Json.tuple(e6.name, e6.toJson(tuple._6)),
-                Json.tuple(e7.name, e7.toJson(tuple._7)),
-                Json.tuple(e8.name, e8.toJson(tuple._8)),
-                Json.tuple(e9.name, e9.toJson(tuple._9)),
-                Json.tuple(e10.name, e10.toJson(tuple._10)),
-                Json.tuple(e11.name, e11.toJson(tuple._11)),
-                Json.tuple(e12.name, e12.toJson(tuple._12)),
-                Json.tuple(e13.name, e13.toJson(tuple._13)),
-                Json.tuple(e14.name, e14.toJson(tuple._14)),
-                Json.tuple(e15.name, e15.toJson(tuple._15)),
-                Json.tuple(e16.name, e16.toJson(tuple._16)),
-                Json.tuple(e17.name, e17.toJson(tuple._17)),
-                Json.tuple(e18.name, e18.toJson(tuple._18)),
-                Json.tuple(e19.name, e19.toJson(tuple._19)),
-                Json.tuple(e20.name, e20.toJson(tuple._20))
+                Json.tuple(e1.name, e1.toJson(tuple._1())),
+                Json.tuple(e2.name, e2.toJson(tuple._2())),
+                Json.tuple(e3.name, e3.toJson(tuple._3())),
+                Json.tuple(e4.name, e4.toJson(tuple._4())),
+                Json.tuple(e5.name, e5.toJson(tuple._5())),
+                Json.tuple(e6.name, e6.toJson(tuple._6())),
+                Json.tuple(e7.name, e7.toJson(tuple._7())),
+                Json.tuple(e8.name, e8.toJson(tuple._8())),
+                Json.tuple(e9.name, e9.toJson(tuple._9())),
+                Json.tuple(e10.name, e10.toJson(tuple._10())),
+                Json.tuple(e11.name, e11.toJson(tuple._11())),
+                Json.tuple(e12.name, e12.toJson(tuple._12())),
+                Json.tuple(e13.name, e13.toJson(tuple._13())),
+                Json.tuple(e14.name, e14.toJson(tuple._14())),
+                Json.tuple(e15.name, e15.toJson(tuple._15())),
+                Json.tuple(e16.name, e16.toJson(tuple._16())),
+                Json.tuple(e17.name, e17.toJson(tuple._17())),
+                Json.tuple(e18.name, e18.toJson(tuple._18())),
+                Json.tuple(e19.name, e19.toJson(tuple._19())),
+                Json.tuple(e20.name, e20.toJson(tuple._20()))
         );
     }
 
@@ -438,27 +438,27 @@ public abstract class Encoders {
 
     public static <A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21> EncodeJson<Tuple21<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21>> encode(FieldEncoder<A1> e1, FieldEncoder<A2> e2, FieldEncoder<A3> e3, FieldEncoder<A4> e4, FieldEncoder<A5> e5, FieldEncoder<A6> e6, FieldEncoder<A7> e7, FieldEncoder<A8> e8, FieldEncoder<A9> e9, FieldEncoder<A10> e10, FieldEncoder<A11> e11, FieldEncoder<A12> e12, FieldEncoder<A13> e13, FieldEncoder<A14> e14, FieldEncoder<A15> e15, FieldEncoder<A16> e16, FieldEncoder<A17> e17, FieldEncoder<A18> e18, FieldEncoder<A19> e19, FieldEncoder<A20> e20, FieldEncoder<A21> e21) {
         return tuple -> Json.jObject(
-                Json.tuple(e1.name, e1.toJson(tuple._1)),
-                Json.tuple(e2.name, e2.toJson(tuple._2)),
-                Json.tuple(e3.name, e3.toJson(tuple._3)),
-                Json.tuple(e4.name, e4.toJson(tuple._4)),
-                Json.tuple(e5.name, e5.toJson(tuple._5)),
-                Json.tuple(e6.name, e6.toJson(tuple._6)),
-                Json.tuple(e7.name, e7.toJson(tuple._7)),
-                Json.tuple(e8.name, e8.toJson(tuple._8)),
-                Json.tuple(e9.name, e9.toJson(tuple._9)),
-                Json.tuple(e10.name, e10.toJson(tuple._10)),
-                Json.tuple(e11.name, e11.toJson(tuple._11)),
-                Json.tuple(e12.name, e12.toJson(tuple._12)),
-                Json.tuple(e13.name, e13.toJson(tuple._13)),
-                Json.tuple(e14.name, e14.toJson(tuple._14)),
-                Json.tuple(e15.name, e15.toJson(tuple._15)),
-                Json.tuple(e16.name, e16.toJson(tuple._16)),
-                Json.tuple(e17.name, e17.toJson(tuple._17)),
-                Json.tuple(e18.name, e18.toJson(tuple._18)),
-                Json.tuple(e19.name, e19.toJson(tuple._19)),
-                Json.tuple(e20.name, e20.toJson(tuple._20)),
-                Json.tuple(e21.name, e21.toJson(tuple._21))
+                Json.tuple(e1.name, e1.toJson(tuple._1())),
+                Json.tuple(e2.name, e2.toJson(tuple._2())),
+                Json.tuple(e3.name, e3.toJson(tuple._3())),
+                Json.tuple(e4.name, e4.toJson(tuple._4())),
+                Json.tuple(e5.name, e5.toJson(tuple._5())),
+                Json.tuple(e6.name, e6.toJson(tuple._6())),
+                Json.tuple(e7.name, e7.toJson(tuple._7())),
+                Json.tuple(e8.name, e8.toJson(tuple._8())),
+                Json.tuple(e9.name, e9.toJson(tuple._9())),
+                Json.tuple(e10.name, e10.toJson(tuple._10())),
+                Json.tuple(e11.name, e11.toJson(tuple._11())),
+                Json.tuple(e12.name, e12.toJson(tuple._12())),
+                Json.tuple(e13.name, e13.toJson(tuple._13())),
+                Json.tuple(e14.name, e14.toJson(tuple._14())),
+                Json.tuple(e15.name, e15.toJson(tuple._15())),
+                Json.tuple(e16.name, e16.toJson(tuple._16())),
+                Json.tuple(e17.name, e17.toJson(tuple._17())),
+                Json.tuple(e18.name, e18.toJson(tuple._18())),
+                Json.tuple(e19.name, e19.toJson(tuple._19())),
+                Json.tuple(e20.name, e20.toJson(tuple._20())),
+                Json.tuple(e21.name, e21.toJson(tuple._21()))
         );
     }
 
@@ -468,28 +468,28 @@ public abstract class Encoders {
 
     public static <A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22> EncodeJson<Tuple22<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22>> encode(FieldEncoder<A1> e1, FieldEncoder<A2> e2, FieldEncoder<A3> e3, FieldEncoder<A4> e4, FieldEncoder<A5> e5, FieldEncoder<A6> e6, FieldEncoder<A7> e7, FieldEncoder<A8> e8, FieldEncoder<A9> e9, FieldEncoder<A10> e10, FieldEncoder<A11> e11, FieldEncoder<A12> e12, FieldEncoder<A13> e13, FieldEncoder<A14> e14, FieldEncoder<A15> e15, FieldEncoder<A16> e16, FieldEncoder<A17> e17, FieldEncoder<A18> e18, FieldEncoder<A19> e19, FieldEncoder<A20> e20, FieldEncoder<A21> e21, FieldEncoder<A22> e22) {
         return tuple -> Json.jObject(
-                Json.tuple(e1.name, e1.toJson(tuple._1)),
-                Json.tuple(e2.name, e2.toJson(tuple._2)),
-                Json.tuple(e3.name, e3.toJson(tuple._3)),
-                Json.tuple(e4.name, e4.toJson(tuple._4)),
-                Json.tuple(e5.name, e5.toJson(tuple._5)),
-                Json.tuple(e6.name, e6.toJson(tuple._6)),
-                Json.tuple(e7.name, e7.toJson(tuple._7)),
-                Json.tuple(e8.name, e8.toJson(tuple._8)),
-                Json.tuple(e9.name, e9.toJson(tuple._9)),
-                Json.tuple(e10.name, e10.toJson(tuple._10)),
-                Json.tuple(e11.name, e11.toJson(tuple._11)),
-                Json.tuple(e12.name, e12.toJson(tuple._12)),
-                Json.tuple(e13.name, e13.toJson(tuple._13)),
-                Json.tuple(e14.name, e14.toJson(tuple._14)),
-                Json.tuple(e15.name, e15.toJson(tuple._15)),
-                Json.tuple(e16.name, e16.toJson(tuple._16)),
-                Json.tuple(e17.name, e17.toJson(tuple._17)),
-                Json.tuple(e18.name, e18.toJson(tuple._18)),
-                Json.tuple(e19.name, e19.toJson(tuple._19)),
-                Json.tuple(e20.name, e20.toJson(tuple._20)),
-                Json.tuple(e21.name, e21.toJson(tuple._21)),
-                Json.tuple(e22.name, e22.toJson(tuple._22))
+                Json.tuple(e1.name, e1.toJson(tuple._1())),
+                Json.tuple(e2.name, e2.toJson(tuple._2())),
+                Json.tuple(e3.name, e3.toJson(tuple._3())),
+                Json.tuple(e4.name, e4.toJson(tuple._4())),
+                Json.tuple(e5.name, e5.toJson(tuple._5())),
+                Json.tuple(e6.name, e6.toJson(tuple._6())),
+                Json.tuple(e7.name, e7.toJson(tuple._7())),
+                Json.tuple(e8.name, e8.toJson(tuple._8())),
+                Json.tuple(e9.name, e9.toJson(tuple._9())),
+                Json.tuple(e10.name, e10.toJson(tuple._10())),
+                Json.tuple(e11.name, e11.toJson(tuple._11())),
+                Json.tuple(e12.name, e12.toJson(tuple._12())),
+                Json.tuple(e13.name, e13.toJson(tuple._13())),
+                Json.tuple(e14.name, e14.toJson(tuple._14())),
+                Json.tuple(e15.name, e15.toJson(tuple._15())),
+                Json.tuple(e16.name, e16.toJson(tuple._16())),
+                Json.tuple(e17.name, e17.toJson(tuple._17())),
+                Json.tuple(e18.name, e18.toJson(tuple._18())),
+                Json.tuple(e19.name, e19.toJson(tuple._19())),
+                Json.tuple(e20.name, e20.toJson(tuple._20())),
+                Json.tuple(e21.name, e21.toJson(tuple._21())),
+                Json.tuple(e22.name, e22.toJson(tuple._22()))
         );
     }
 
@@ -499,29 +499,29 @@ public abstract class Encoders {
 
     public static <A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, A23> EncodeJson<Tuple23<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, A23>> encode(FieldEncoder<A1> e1, FieldEncoder<A2> e2, FieldEncoder<A3> e3, FieldEncoder<A4> e4, FieldEncoder<A5> e5, FieldEncoder<A6> e6, FieldEncoder<A7> e7, FieldEncoder<A8> e8, FieldEncoder<A9> e9, FieldEncoder<A10> e10, FieldEncoder<A11> e11, FieldEncoder<A12> e12, FieldEncoder<A13> e13, FieldEncoder<A14> e14, FieldEncoder<A15> e15, FieldEncoder<A16> e16, FieldEncoder<A17> e17, FieldEncoder<A18> e18, FieldEncoder<A19> e19, FieldEncoder<A20> e20, FieldEncoder<A21> e21, FieldEncoder<A22> e22, FieldEncoder<A23> e23) {
         return tuple -> Json.jObject(
-                Json.tuple(e1.name, e1.toJson(tuple._1)),
-                Json.tuple(e2.name, e2.toJson(tuple._2)),
-                Json.tuple(e3.name, e3.toJson(tuple._3)),
-                Json.tuple(e4.name, e4.toJson(tuple._4)),
-                Json.tuple(e5.name, e5.toJson(tuple._5)),
-                Json.tuple(e6.name, e6.toJson(tuple._6)),
-                Json.tuple(e7.name, e7.toJson(tuple._7)),
-                Json.tuple(e8.name, e8.toJson(tuple._8)),
-                Json.tuple(e9.name, e9.toJson(tuple._9)),
-                Json.tuple(e10.name, e10.toJson(tuple._10)),
-                Json.tuple(e11.name, e11.toJson(tuple._11)),
-                Json.tuple(e12.name, e12.toJson(tuple._12)),
-                Json.tuple(e13.name, e13.toJson(tuple._13)),
-                Json.tuple(e14.name, e14.toJson(tuple._14)),
-                Json.tuple(e15.name, e15.toJson(tuple._15)),
-                Json.tuple(e16.name, e16.toJson(tuple._16)),
-                Json.tuple(e17.name, e17.toJson(tuple._17)),
-                Json.tuple(e18.name, e18.toJson(tuple._18)),
-                Json.tuple(e19.name, e19.toJson(tuple._19)),
-                Json.tuple(e20.name, e20.toJson(tuple._20)),
-                Json.tuple(e21.name, e21.toJson(tuple._21)),
-                Json.tuple(e22.name, e22.toJson(tuple._22)),
-                Json.tuple(e23.name, e23.toJson(tuple._23))
+                Json.tuple(e1.name, e1.toJson(tuple._1())),
+                Json.tuple(e2.name, e2.toJson(tuple._2())),
+                Json.tuple(e3.name, e3.toJson(tuple._3())),
+                Json.tuple(e4.name, e4.toJson(tuple._4())),
+                Json.tuple(e5.name, e5.toJson(tuple._5())),
+                Json.tuple(e6.name, e6.toJson(tuple._6())),
+                Json.tuple(e7.name, e7.toJson(tuple._7())),
+                Json.tuple(e8.name, e8.toJson(tuple._8())),
+                Json.tuple(e9.name, e9.toJson(tuple._9())),
+                Json.tuple(e10.name, e10.toJson(tuple._10())),
+                Json.tuple(e11.name, e11.toJson(tuple._11())),
+                Json.tuple(e12.name, e12.toJson(tuple._12())),
+                Json.tuple(e13.name, e13.toJson(tuple._13())),
+                Json.tuple(e14.name, e14.toJson(tuple._14())),
+                Json.tuple(e15.name, e15.toJson(tuple._15())),
+                Json.tuple(e16.name, e16.toJson(tuple._16())),
+                Json.tuple(e17.name, e17.toJson(tuple._17())),
+                Json.tuple(e18.name, e18.toJson(tuple._18())),
+                Json.tuple(e19.name, e19.toJson(tuple._19())),
+                Json.tuple(e20.name, e20.toJson(tuple._20())),
+                Json.tuple(e21.name, e21.toJson(tuple._21())),
+                Json.tuple(e22.name, e22.toJson(tuple._22())),
+                Json.tuple(e23.name, e23.toJson(tuple._23()))
         );
     }
 
@@ -531,30 +531,30 @@ public abstract class Encoders {
 
     public static <A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, A23, A24> EncodeJson<Tuple24<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, A23, A24>> encode(FieldEncoder<A1> e1, FieldEncoder<A2> e2, FieldEncoder<A3> e3, FieldEncoder<A4> e4, FieldEncoder<A5> e5, FieldEncoder<A6> e6, FieldEncoder<A7> e7, FieldEncoder<A8> e8, FieldEncoder<A9> e9, FieldEncoder<A10> e10, FieldEncoder<A11> e11, FieldEncoder<A12> e12, FieldEncoder<A13> e13, FieldEncoder<A14> e14, FieldEncoder<A15> e15, FieldEncoder<A16> e16, FieldEncoder<A17> e17, FieldEncoder<A18> e18, FieldEncoder<A19> e19, FieldEncoder<A20> e20, FieldEncoder<A21> e21, FieldEncoder<A22> e22, FieldEncoder<A23> e23, FieldEncoder<A24> e24) {
         return tuple -> Json.jObject(
-                Json.tuple(e1.name, e1.toJson(tuple._1)),
-                Json.tuple(e2.name, e2.toJson(tuple._2)),
-                Json.tuple(e3.name, e3.toJson(tuple._3)),
-                Json.tuple(e4.name, e4.toJson(tuple._4)),
-                Json.tuple(e5.name, e5.toJson(tuple._5)),
-                Json.tuple(e6.name, e6.toJson(tuple._6)),
-                Json.tuple(e7.name, e7.toJson(tuple._7)),
-                Json.tuple(e8.name, e8.toJson(tuple._8)),
-                Json.tuple(e9.name, e9.toJson(tuple._9)),
-                Json.tuple(e10.name, e10.toJson(tuple._10)),
-                Json.tuple(e11.name, e11.toJson(tuple._11)),
-                Json.tuple(e12.name, e12.toJson(tuple._12)),
-                Json.tuple(e13.name, e13.toJson(tuple._13)),
-                Json.tuple(e14.name, e14.toJson(tuple._14)),
-                Json.tuple(e15.name, e15.toJson(tuple._15)),
-                Json.tuple(e16.name, e16.toJson(tuple._16)),
-                Json.tuple(e17.name, e17.toJson(tuple._17)),
-                Json.tuple(e18.name, e18.toJson(tuple._18)),
-                Json.tuple(e19.name, e19.toJson(tuple._19)),
-                Json.tuple(e20.name, e20.toJson(tuple._20)),
-                Json.tuple(e21.name, e21.toJson(tuple._21)),
-                Json.tuple(e22.name, e22.toJson(tuple._22)),
-                Json.tuple(e23.name, e23.toJson(tuple._23)),
-                Json.tuple(e24.name, e24.toJson(tuple._24))
+                Json.tuple(e1.name, e1.toJson(tuple._1())),
+                Json.tuple(e2.name, e2.toJson(tuple._2())),
+                Json.tuple(e3.name, e3.toJson(tuple._3())),
+                Json.tuple(e4.name, e4.toJson(tuple._4())),
+                Json.tuple(e5.name, e5.toJson(tuple._5())),
+                Json.tuple(e6.name, e6.toJson(tuple._6())),
+                Json.tuple(e7.name, e7.toJson(tuple._7())),
+                Json.tuple(e8.name, e8.toJson(tuple._8())),
+                Json.tuple(e9.name, e9.toJson(tuple._9())),
+                Json.tuple(e10.name, e10.toJson(tuple._10())),
+                Json.tuple(e11.name, e11.toJson(tuple._11())),
+                Json.tuple(e12.name, e12.toJson(tuple._12())),
+                Json.tuple(e13.name, e13.toJson(tuple._13())),
+                Json.tuple(e14.name, e14.toJson(tuple._14())),
+                Json.tuple(e15.name, e15.toJson(tuple._15())),
+                Json.tuple(e16.name, e16.toJson(tuple._16())),
+                Json.tuple(e17.name, e17.toJson(tuple._17())),
+                Json.tuple(e18.name, e18.toJson(tuple._18())),
+                Json.tuple(e19.name, e19.toJson(tuple._19())),
+                Json.tuple(e20.name, e20.toJson(tuple._20())),
+                Json.tuple(e21.name, e21.toJson(tuple._21())),
+                Json.tuple(e22.name, e22.toJson(tuple._22())),
+                Json.tuple(e23.name, e23.toJson(tuple._23())),
+                Json.tuple(e24.name, e24.toJson(tuple._24()))
         );
     }
 
@@ -564,31 +564,31 @@ public abstract class Encoders {
 
     public static <A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, A23, A24, A25> EncodeJson<Tuple25<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, A23, A24, A25>> encode(FieldEncoder<A1> e1, FieldEncoder<A2> e2, FieldEncoder<A3> e3, FieldEncoder<A4> e4, FieldEncoder<A5> e5, FieldEncoder<A6> e6, FieldEncoder<A7> e7, FieldEncoder<A8> e8, FieldEncoder<A9> e9, FieldEncoder<A10> e10, FieldEncoder<A11> e11, FieldEncoder<A12> e12, FieldEncoder<A13> e13, FieldEncoder<A14> e14, FieldEncoder<A15> e15, FieldEncoder<A16> e16, FieldEncoder<A17> e17, FieldEncoder<A18> e18, FieldEncoder<A19> e19, FieldEncoder<A20> e20, FieldEncoder<A21> e21, FieldEncoder<A22> e22, FieldEncoder<A23> e23, FieldEncoder<A24> e24, FieldEncoder<A25> e25) {
         return tuple -> Json.jObject(
-                Json.tuple(e1.name, e1.toJson(tuple._1)),
-                Json.tuple(e2.name, e2.toJson(tuple._2)),
-                Json.tuple(e3.name, e3.toJson(tuple._3)),
-                Json.tuple(e4.name, e4.toJson(tuple._4)),
-                Json.tuple(e5.name, e5.toJson(tuple._5)),
-                Json.tuple(e6.name, e6.toJson(tuple._6)),
-                Json.tuple(e7.name, e7.toJson(tuple._7)),
-                Json.tuple(e8.name, e8.toJson(tuple._8)),
-                Json.tuple(e9.name, e9.toJson(tuple._9)),
-                Json.tuple(e10.name, e10.toJson(tuple._10)),
-                Json.tuple(e11.name, e11.toJson(tuple._11)),
-                Json.tuple(e12.name, e12.toJson(tuple._12)),
-                Json.tuple(e13.name, e13.toJson(tuple._13)),
-                Json.tuple(e14.name, e14.toJson(tuple._14)),
-                Json.tuple(e15.name, e15.toJson(tuple._15)),
-                Json.tuple(e16.name, e16.toJson(tuple._16)),
-                Json.tuple(e17.name, e17.toJson(tuple._17)),
-                Json.tuple(e18.name, e18.toJson(tuple._18)),
-                Json.tuple(e19.name, e19.toJson(tuple._19)),
-                Json.tuple(e20.name, e20.toJson(tuple._20)),
-                Json.tuple(e21.name, e21.toJson(tuple._21)),
-                Json.tuple(e22.name, e22.toJson(tuple._22)),
-                Json.tuple(e23.name, e23.toJson(tuple._23)),
-                Json.tuple(e24.name, e24.toJson(tuple._24)),
-                Json.tuple(e25.name, e25.toJson(tuple._25))
+                Json.tuple(e1.name, e1.toJson(tuple._1())),
+                Json.tuple(e2.name, e2.toJson(tuple._2())),
+                Json.tuple(e3.name, e3.toJson(tuple._3())),
+                Json.tuple(e4.name, e4.toJson(tuple._4())),
+                Json.tuple(e5.name, e5.toJson(tuple._5())),
+                Json.tuple(e6.name, e6.toJson(tuple._6())),
+                Json.tuple(e7.name, e7.toJson(tuple._7())),
+                Json.tuple(e8.name, e8.toJson(tuple._8())),
+                Json.tuple(e9.name, e9.toJson(tuple._9())),
+                Json.tuple(e10.name, e10.toJson(tuple._10())),
+                Json.tuple(e11.name, e11.toJson(tuple._11())),
+                Json.tuple(e12.name, e12.toJson(tuple._12())),
+                Json.tuple(e13.name, e13.toJson(tuple._13())),
+                Json.tuple(e14.name, e14.toJson(tuple._14())),
+                Json.tuple(e15.name, e15.toJson(tuple._15())),
+                Json.tuple(e16.name, e16.toJson(tuple._16())),
+                Json.tuple(e17.name, e17.toJson(tuple._17())),
+                Json.tuple(e18.name, e18.toJson(tuple._18())),
+                Json.tuple(e19.name, e19.toJson(tuple._19())),
+                Json.tuple(e20.name, e20.toJson(tuple._20())),
+                Json.tuple(e21.name, e21.toJson(tuple._21())),
+                Json.tuple(e22.name, e22.toJson(tuple._22())),
+                Json.tuple(e23.name, e23.toJson(tuple._23())),
+                Json.tuple(e24.name, e24.toJson(tuple._24())),
+                Json.tuple(e25.name, e25.toJson(tuple._25()))
         );
     }
 
@@ -598,32 +598,32 @@ public abstract class Encoders {
 
     public static <A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, A23, A24, A25, A26> EncodeJson<Tuple26<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, A23, A24, A25, A26>> encode(FieldEncoder<A1> e1, FieldEncoder<A2> e2, FieldEncoder<A3> e3, FieldEncoder<A4> e4, FieldEncoder<A5> e5, FieldEncoder<A6> e6, FieldEncoder<A7> e7, FieldEncoder<A8> e8, FieldEncoder<A9> e9, FieldEncoder<A10> e10, FieldEncoder<A11> e11, FieldEncoder<A12> e12, FieldEncoder<A13> e13, FieldEncoder<A14> e14, FieldEncoder<A15> e15, FieldEncoder<A16> e16, FieldEncoder<A17> e17, FieldEncoder<A18> e18, FieldEncoder<A19> e19, FieldEncoder<A20> e20, FieldEncoder<A21> e21, FieldEncoder<A22> e22, FieldEncoder<A23> e23, FieldEncoder<A24> e24, FieldEncoder<A25> e25, FieldEncoder<A26> e26) {
         return tuple -> Json.jObject(
-                Json.tuple(e1.name, e1.toJson(tuple._1)),
-                Json.tuple(e2.name, e2.toJson(tuple._2)),
-                Json.tuple(e3.name, e3.toJson(tuple._3)),
-                Json.tuple(e4.name, e4.toJson(tuple._4)),
-                Json.tuple(e5.name, e5.toJson(tuple._5)),
-                Json.tuple(e6.name, e6.toJson(tuple._6)),
-                Json.tuple(e7.name, e7.toJson(tuple._7)),
-                Json.tuple(e8.name, e8.toJson(tuple._8)),
-                Json.tuple(e9.name, e9.toJson(tuple._9)),
-                Json.tuple(e10.name, e10.toJson(tuple._10)),
-                Json.tuple(e11.name, e11.toJson(tuple._11)),
-                Json.tuple(e12.name, e12.toJson(tuple._12)),
-                Json.tuple(e13.name, e13.toJson(tuple._13)),
-                Json.tuple(e14.name, e14.toJson(tuple._14)),
-                Json.tuple(e15.name, e15.toJson(tuple._15)),
-                Json.tuple(e16.name, e16.toJson(tuple._16)),
-                Json.tuple(e17.name, e17.toJson(tuple._17)),
-                Json.tuple(e18.name, e18.toJson(tuple._18)),
-                Json.tuple(e19.name, e19.toJson(tuple._19)),
-                Json.tuple(e20.name, e20.toJson(tuple._20)),
-                Json.tuple(e21.name, e21.toJson(tuple._21)),
-                Json.tuple(e22.name, e22.toJson(tuple._22)),
-                Json.tuple(e23.name, e23.toJson(tuple._23)),
-                Json.tuple(e24.name, e24.toJson(tuple._24)),
-                Json.tuple(e25.name, e25.toJson(tuple._25)),
-                Json.tuple(e26.name, e26.toJson(tuple._26))
+                Json.tuple(e1.name, e1.toJson(tuple._1())),
+                Json.tuple(e2.name, e2.toJson(tuple._2())),
+                Json.tuple(e3.name, e3.toJson(tuple._3())),
+                Json.tuple(e4.name, e4.toJson(tuple._4())),
+                Json.tuple(e5.name, e5.toJson(tuple._5())),
+                Json.tuple(e6.name, e6.toJson(tuple._6())),
+                Json.tuple(e7.name, e7.toJson(tuple._7())),
+                Json.tuple(e8.name, e8.toJson(tuple._8())),
+                Json.tuple(e9.name, e9.toJson(tuple._9())),
+                Json.tuple(e10.name, e10.toJson(tuple._10())),
+                Json.tuple(e11.name, e11.toJson(tuple._11())),
+                Json.tuple(e12.name, e12.toJson(tuple._12())),
+                Json.tuple(e13.name, e13.toJson(tuple._13())),
+                Json.tuple(e14.name, e14.toJson(tuple._14())),
+                Json.tuple(e15.name, e15.toJson(tuple._15())),
+                Json.tuple(e16.name, e16.toJson(tuple._16())),
+                Json.tuple(e17.name, e17.toJson(tuple._17())),
+                Json.tuple(e18.name, e18.toJson(tuple._18())),
+                Json.tuple(e19.name, e19.toJson(tuple._19())),
+                Json.tuple(e20.name, e20.toJson(tuple._20())),
+                Json.tuple(e21.name, e21.toJson(tuple._21())),
+                Json.tuple(e22.name, e22.toJson(tuple._22())),
+                Json.tuple(e23.name, e23.toJson(tuple._23())),
+                Json.tuple(e24.name, e24.toJson(tuple._24())),
+                Json.tuple(e25.name, e25.toJson(tuple._25())),
+                Json.tuple(e26.name, e26.toJson(tuple._26()))
         );
     }
 
@@ -633,33 +633,33 @@ public abstract class Encoders {
 
     public static <A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, A23, A24, A25, A26, A27> EncodeJson<Tuple27<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, A23, A24, A25, A26, A27>> encode(FieldEncoder<A1> e1, FieldEncoder<A2> e2, FieldEncoder<A3> e3, FieldEncoder<A4> e4, FieldEncoder<A5> e5, FieldEncoder<A6> e6, FieldEncoder<A7> e7, FieldEncoder<A8> e8, FieldEncoder<A9> e9, FieldEncoder<A10> e10, FieldEncoder<A11> e11, FieldEncoder<A12> e12, FieldEncoder<A13> e13, FieldEncoder<A14> e14, FieldEncoder<A15> e15, FieldEncoder<A16> e16, FieldEncoder<A17> e17, FieldEncoder<A18> e18, FieldEncoder<A19> e19, FieldEncoder<A20> e20, FieldEncoder<A21> e21, FieldEncoder<A22> e22, FieldEncoder<A23> e23, FieldEncoder<A24> e24, FieldEncoder<A25> e25, FieldEncoder<A26> e26, FieldEncoder<A27> e27) {
         return tuple -> Json.jObject(
-                Json.tuple(e1.name, e1.toJson(tuple._1)),
-                Json.tuple(e2.name, e2.toJson(tuple._2)),
-                Json.tuple(e3.name, e3.toJson(tuple._3)),
-                Json.tuple(e4.name, e4.toJson(tuple._4)),
-                Json.tuple(e5.name, e5.toJson(tuple._5)),
-                Json.tuple(e6.name, e6.toJson(tuple._6)),
-                Json.tuple(e7.name, e7.toJson(tuple._7)),
-                Json.tuple(e8.name, e8.toJson(tuple._8)),
-                Json.tuple(e9.name, e9.toJson(tuple._9)),
-                Json.tuple(e10.name, e10.toJson(tuple._10)),
-                Json.tuple(e11.name, e11.toJson(tuple._11)),
-                Json.tuple(e12.name, e12.toJson(tuple._12)),
-                Json.tuple(e13.name, e13.toJson(tuple._13)),
-                Json.tuple(e14.name, e14.toJson(tuple._14)),
-                Json.tuple(e15.name, e15.toJson(tuple._15)),
-                Json.tuple(e16.name, e16.toJson(tuple._16)),
-                Json.tuple(e17.name, e17.toJson(tuple._17)),
-                Json.tuple(e18.name, e18.toJson(tuple._18)),
-                Json.tuple(e19.name, e19.toJson(tuple._19)),
-                Json.tuple(e20.name, e20.toJson(tuple._20)),
-                Json.tuple(e21.name, e21.toJson(tuple._21)),
-                Json.tuple(e22.name, e22.toJson(tuple._22)),
-                Json.tuple(e23.name, e23.toJson(tuple._23)),
-                Json.tuple(e24.name, e24.toJson(tuple._24)),
-                Json.tuple(e25.name, e25.toJson(tuple._25)),
-                Json.tuple(e26.name, e26.toJson(tuple._26)),
-                Json.tuple(e27.name, e27.toJson(tuple._27))
+                Json.tuple(e1.name, e1.toJson(tuple._1())),
+                Json.tuple(e2.name, e2.toJson(tuple._2())),
+                Json.tuple(e3.name, e3.toJson(tuple._3())),
+                Json.tuple(e4.name, e4.toJson(tuple._4())),
+                Json.tuple(e5.name, e5.toJson(tuple._5())),
+                Json.tuple(e6.name, e6.toJson(tuple._6())),
+                Json.tuple(e7.name, e7.toJson(tuple._7())),
+                Json.tuple(e8.name, e8.toJson(tuple._8())),
+                Json.tuple(e9.name, e9.toJson(tuple._9())),
+                Json.tuple(e10.name, e10.toJson(tuple._10())),
+                Json.tuple(e11.name, e11.toJson(tuple._11())),
+                Json.tuple(e12.name, e12.toJson(tuple._12())),
+                Json.tuple(e13.name, e13.toJson(tuple._13())),
+                Json.tuple(e14.name, e14.toJson(tuple._14())),
+                Json.tuple(e15.name, e15.toJson(tuple._15())),
+                Json.tuple(e16.name, e16.toJson(tuple._16())),
+                Json.tuple(e17.name, e17.toJson(tuple._17())),
+                Json.tuple(e18.name, e18.toJson(tuple._18())),
+                Json.tuple(e19.name, e19.toJson(tuple._19())),
+                Json.tuple(e20.name, e20.toJson(tuple._20())),
+                Json.tuple(e21.name, e21.toJson(tuple._21())),
+                Json.tuple(e22.name, e22.toJson(tuple._22())),
+                Json.tuple(e23.name, e23.toJson(tuple._23())),
+                Json.tuple(e24.name, e24.toJson(tuple._24())),
+                Json.tuple(e25.name, e25.toJson(tuple._25())),
+                Json.tuple(e26.name, e26.toJson(tuple._26())),
+                Json.tuple(e27.name, e27.toJson(tuple._27()))
         );
     }
 

--- a/codec/src/test/java/net/hamnaberg/json/codec/PersonCodecTest.java
+++ b/codec/src/test/java/net/hamnaberg/json/codec/PersonCodecTest.java
@@ -107,7 +107,7 @@ public class PersonCodecTest {
 
         @Override
         public Person reverseGet(Tuple3<String, Integer, Address> t) {
-            return new Person(t._1, t._2, t._3);
+            return new Person(t._1(), t._2(), t._3());
         }
 
         @Override
@@ -121,7 +121,7 @@ public class PersonCodecTest {
 
         @Override
         public Person2 reverseGet(Tuple3<String, Integer, Optional<Address>> t) {
-            return new Person2(t._1, t._2, t._3);
+            return new Person2(t._1(), t._2(), t._3());
         }
 
         @Override
@@ -135,7 +135,7 @@ public class PersonCodecTest {
 
         @Override
         public Address reverseGet(Tuple2<String, String>t) {
-            return new Address(t._1, t._2);
+            return new Address(t._1(), t._2());
         }
 
         @Override

--- a/pointer/src/main/java/net/hamnaberg/json/pointer/JsonPointer.java
+++ b/pointer/src/main/java/net/hamnaberg/json/pointer/JsonPointer.java
@@ -1,5 +1,6 @@
 package net.hamnaberg.json.pointer;
 
+import net.hamnaberg.json.Folder;
 import net.hamnaberg.json.Json;
 
 import java.util.Iterator;
@@ -113,7 +114,7 @@ public final class JsonPointer {
     }
 
     private Json.JValue foldToJson(Json.JValue value, Function<Json.JObject, Json.JValue> fObject, Function<Json.JArray, Json.JValue> fArray) {
-        return value.fold(Json.Folder.from(
+        return value.fold(Folder.from(
                 Json.JValue::asJValue,
                 Json.JValue::asJValue,
                 Json.JValue::asJValue,

--- a/pointer/src/main/java/net/hamnaberg/json/pointer/JsonPointer.java
+++ b/pointer/src/main/java/net/hamnaberg/json/pointer/JsonPointer.java
@@ -113,14 +113,14 @@ public final class JsonPointer {
     }
 
     private Json.JValue foldToJson(Json.JValue value, Function<Json.JObject, Json.JValue> fObject, Function<Json.JArray, Json.JValue> fArray) {
-        return value.fold(
+        return value.fold(Json.Folder.from(
                 Json.JValue::asJValue,
                 Json.JValue::asJValue,
                 Json.JValue::asJValue,
                 fObject,
                 fArray,
                 Json::jNull
-        );
+        ));
     }
 
     private Json.JValue updateImpl(Iterator<Ref> path, Ref ref, Json.JValue context, Optional<Json.JValue> updateValue) {
@@ -135,8 +135,7 @@ public final class JsonPointer {
                                 if (updateValue.isPresent()) {
                                     array.get(index).orElseThrow(() -> new IllegalStateException("No value at index: " + index));
                                     return array.replace(index, updateValue.get());
-                                }
-                                else {
+                                } else {
                                     return array.remove(index);
                                 }
                             } else {
@@ -179,8 +178,7 @@ public final class JsonPointer {
                             if (!path.hasNext()) {
                                 if (arr.size() >= index) {
                                     return arr.insert(index, valueToInsert);
-                                }
-                                else {
+                                } else {
                                     throw new IllegalStateException(String.format("List index %s is out-of-bounds", index));
                                 }
                             } else {
@@ -195,16 +193,16 @@ public final class JsonPointer {
                         Json.JValue::asJValue
                 ),
                 () ->
-                    foldToJson(
-                            context,
-                            j -> j,
-                            arr -> {
-                                if (path.hasNext()) {
-                                    throw new IllegalStateException("Nonsense to have more values after a end-of-array");
+                        foldToJson(
+                                context,
+                                j -> j,
+                                arr -> {
+                                    if (path.hasNext()) {
+                                        throw new IllegalStateException("Nonsense to have more values after a end-of-array");
+                                    }
+                                    return arr.append(valueToInsert);
                                 }
-                                return arr.append(valueToInsert);
-                            }
-                    )
+                        )
         );
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.13.0</version>
           <configuration>
-            <release>11</release>
+            <release>17</release>
             <compilerArgs>
               <arg>-Xlint:unchecked</arg>
               <arg>-Xlint:deprecation</arg>


### PR DESCRIPTION
JValue is now a real sealed interface
Use records for implementations of JValue except for JNull which is an enum

Change fold to use a Visitor instead
Printer is now simpler, most logic is now within the folder, should allow us to have multiple implementors of state.